### PR TITLE
chore: rename project from llm-proxy to openproxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "llm-proxy"
+name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
 version = "2.1.21"
 edition = "2021"
 description = "A LLM Proxy"
 
 [[bin]]
-name = "llm-proxy"
+name = "openproxy"
 path = "src/main.rs"
 
 [dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,17 @@ COPY Cargo.toml ./
 COPY src ./src
 
 # Build the application
-RUN cargo build --release --bin llm-proxy
+RUN cargo build --release --bin openproxy
 
 # Runtime stage
 FROM ubuntu:22.04
 
 # Copy the binary from builder stage
-COPY --from=builder /usr/src/app/target/release/llm-proxy /usr/local/bin/llm-proxy
+COPY --from=builder /usr/src/app/target/release/openproxy /usr/local/bin/openproxy
 
 # Expose port
 EXPOSE 443
 
 # Run the application
-ENTRYPOINT ["/usr/local/bin/llm-proxy"]
+ENTRYPOINT ["/usr/local/bin/openproxy"]
 CMD ["start", "-c", "/config.yml", "--enable-health-check"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LLM Proxy
+# OpenProxy
 
 A high-performance LLM (Large Language Model) proxy server written in Rust, designed to intelligently route requests between multiple LLM providers with advanced features like weighted load balancing, health checks, and connection pooling.
 
@@ -20,8 +20,8 @@ A high-performance LLM (Large Language Model) proxy server written in Rust, desi
 ### From Source
 
 ```bash
-git clone https://github.com/x5iu/llm-proxy.git
-cd llm-proxy
+git clone https://github.com/x5iu/openproxy.git
+cd openproxy
 cargo build --release
 ```
 
@@ -30,12 +30,12 @@ cargo build --release
 ```bash
 # Pull and run the pre-built image
 docker run -d \
-  --name llm-proxy \
+  --name openproxy \
   -p 443:443 \
   -v /path/to/config.yml:/config.yml \
   -v /path/to/certificate.pem:/certs/certificate.pem \
   -v /path/to/private-key.pem:/certs/private-key.pem \
-  x5iu/llm-proxy:latest
+  x5iu/openproxy:latest
 ```
 
 ## Configuration
@@ -125,10 +125,10 @@ providers:
 
 ```bash
 # Basic usage
-./llm-proxy start -c config.yml
+./openproxy start -c config.yml
 
 # With health checks enabled
-./llm-proxy start -c config.yml --enable-health-check
+./openproxy start -c config.yml --enable-health-check
 ```
 
 ### Making Requests

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub async fn load_config(
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
         structured_logger::Builder::with_level("INFO")
-            .with_target_writer("llm-proxy*", new_writer(io::stderr()))
+            .with_target_writer("openproxy*", new_writer(io::stderr()))
             .init();
     });
     log::info!(config:serde = config; "load_config");


### PR DESCRIPTION
## Summary

- Rename the project from `llm-proxy` to `openproxy` due to naming conflict with other projects
- Update package name and binary name in Cargo.toml
- Update all related references in README.md, Dockerfile, and source code

## Changes

- `Cargo.toml`: package name & binary name
- `README.md`: title, git clone URL, docker commands, usage examples
- `Dockerfile`: build & runtime binary paths
- `src/main.rs`: crate imports (`llm_proxy` → `openproxy`), struct name, log messages
- `src/lib.rs`: logger target writer name

## Test plan

- [x] `cargo check` passes
- [ ] Manual testing of build and deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)