### PR TITLE
feat: add HTTP (plaintext) connection support

### DIFF
--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -50,11 +50,12 @@ where
     ) -> Pin<Box<dyn Future<Output=Result<<P as PoolTrait>::Item, Error>> + Send + 'a>>
     where
         <P as PoolTrait>::Item: Send;
-    fn proxy<'a>(
+    fn proxy<'a, S>(
         &'a mut self,
-        incoming: &'a mut TlsIncomingStream,
+        incoming: &'a mut S,
     ) -> Pin<Box<dyn Future<Output=Result<(), ProxyError>> + Send + 'a>>
     where
+        S: AsyncRead + AsyncWrite + Unpin + Send + Sync,
         <P as PoolTrait>::Item: Unpin + Send + Sync;
     fn proxy_h2<'a>(
         &'a mut self,
@@ -106,11 +107,12 @@ where
         })
     }
 
-    fn proxy<'a>(
+    fn proxy<'a, S>(
         &'a mut self,
-        mut incoming: &'a mut TlsIncomingStream,
+        mut incoming: &'a mut S,
     ) -> Pin<Box<dyn Future<Output=Result<(), ProxyError>> + Send + 'a>>
     where
+        S: AsyncRead + AsyncWrite + Unpin + Send + Sync,
         <P as PoolTrait>::Item: Unpin + Send + Sync,
     {
         Box::pin(async move {


### PR DESCRIPTION
## Summary

- Add support for HTTP connections in addition to HTTPS
- When using HTTP, only HTTP/1.1 is supported (no HTTP/2)
- Support running both HTTP and HTTPS listeners simultaneously

## Configuration Changes

- `cert_file` and `private_key_file` are now optional
- New `https_port` option to specify HTTPS listening port
- New `http_port` option to specify HTTP listening port
- For backwards compatibility, if only cert files are provided without explicit port config, defaults to HTTPS on port 443

Example configuration (HTTP only):
```yaml
http_port: 80
providers:
  - type: openai
    host: api.example.com
    endpoint: api.openai.com
```

Example configuration (HTTPS only, same as before):
```yaml
cert_file: /path/to/cert.pem
private_key_file: /path/to/key.pem
https_port: 443
providers:
  - type: openai
    host: api.example.com
    endpoint: api.openai.com
```

Example configuration (both HTTP and HTTPS):
```yaml
cert_file: /path/to/cert.pem
private_key_file: /path/to/key.pem
https_port: 443
http_port: 80
providers:
  - type: openai
    host: api.example.com
    endpoint: api.openai.com
```

## Test plan

- [x] `cargo test` passes
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)