### PR TITLE
fix: address P0 security vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ h2 = "0.4.10"
 httplib = { version = "1.3.1", package = "http" }
 httparse = "1.10.1"
 bytes = "1.10.1"
+subtle = "2.6"


### PR DESCRIPTION
## Summary

This PR addresses critical (P0) and high (P1) security vulnerabilities identified during a security audit.

---

## P0 Fixes

### 1. Memory Safety: Remove unsafe Drop implementations

- **Issue**: The three provider types (`OpenAIProvider`, `GeminiProvider`, `AnthropicProvider`) used `Box::leak` to create `'static` references, then manually freed memory in `Drop` implementations using `unsafe { Box::from_raw(...) }`
- **Risk**: This pattern could lead to use-after-free or double-free during hot reload scenarios when multiple threads access provider data
- **Fix**: Replace `Box::leak` + manual `Drop` with `Arc<str>` and `String` types, letting Rust's ownership system handle memory safely

### 2. HTTP Request Smuggling Prevention

- **Issue**: The HTTP parser accepted requests with both `Content-Length` and `Transfer-Encoding: chunked` headers, prioritizing `Content-Length`
- **Risk**: Attackers could exploit the ambiguity between how the proxy and upstream servers interpret request boundaries (CL.TE attacks per RFC 7230 Section 3.3.3)
- **Fix**: Reject requests containing both headers with `InvalidHeader` error

---

## P1 Fixes

### 3. Timing Attack Prevention

- **Issue**: API key authentication used standard string comparison (`==`), which short-circuits on first mismatch
- **Risk**: Attackers could measure response times to infer API keys byte-by-byte through statistical analysis
- **Fix**: Use constant-time comparison via the `subtle` crate's `ConstantTimeEq` trait

### 4. Connection Pool DoS Prevention

- **Issue**: Connection pool had no size limits, allowing unbounded growth
- **Risk**: Attackers could exhaust server memory by rapidly creating connections
- **Fix**: 
  - Add maximum connection limit per endpoint (default: 100)
  - Track connection counts with atomic counters
  - Log warnings when pool reaches capacity
  - Excess connections are dropped instead of pooled

---

## Test plan

- [x] All existing tests pass (`cargo test`)
- [x] `cargo clippy` shows no new warnings from these changes
- [ ] Manual testing with concurrent hot reload scenarios
- [ ] Manual testing with malformed HTTP requests containing both CL and TE headers
- [ ] Load testing to verify connection pool limits work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)