### PR TITLE
feat: add E2E testing with GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,84 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-action@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Generate self-signed certificate
+        run: |
+          openssl req -x509 -newkey rsa:4096 -keyout privkey.pem -out fullchain.pem -days 1 -nodes \
+            -subj "/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+
+      - name: Generate auth key and config
+        run: |
+          AUTH_KEY=$(openssl rand -hex 32)
+          echo "AUTH_KEY=${AUTH_KEY}" >> $GITHUB_ENV
+
+          cat > config.yml << EOF
+          cert_file: $(pwd)/fullchain.pem
+          private_key_file: $(pwd)/privkey.pem
+
+          auth_keys:
+            - ${AUTH_KEY}
+
+          providers:
+            - type: openai
+              host: localhost
+              endpoint: ${{ secrets.OPENAI_HOST }}
+              api_key: ${{ secrets.OPENAI_API_KEY }}
+          EOF
+
+      - name: Build openproxy
+        run: cargo build --release
+
+      - name: Start openproxy
+        run: |
+          ./target/release/openproxy start -c config.yml &
+          sleep 3
+          # Verify the server is running
+          curl -k https://localhost:443 || true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install openai pydantic
+
+      - name: Run E2E tests
+        env:
+          OPENAI_BASE_URL: https://localhost:443/v1
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
+          REQUESTS_CA_BUNDLE: ${{ github.workspace }}/fullchain.pem
+        run: |
+          cd e2e
+          python test.py

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
         uses: actions/cache@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Python dependencies
-        run: pip install openai pydantic httpx
+        run: pip install openai pydantic "httpx[http2]"
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
           AUTH_KEY=$(openssl rand -hex 32)
           echo "AUTH_KEY=${AUTH_KEY}" >> $GITHUB_ENV
 
-          cat > config.yml << EOF
+          cat > config.yml <<EOF
           cert_file: $(pwd)/fullchain.pem
           private_key_file: $(pwd)/privkey.pem
           https_port: 8443
@@ -55,6 +55,9 @@ jobs:
               endpoint: ${{ secrets.OPENAI_HOST }}
               api_key: ${{ secrets.OPENAI_API_KEY }}
           EOF
+
+          # Debug: show generated config
+          cat config.yml
 
       - name: Build openproxy
         run: cargo build --release
@@ -72,7 +75,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install Python dependencies
-        run: pip install openai pydantic
+        run: pip install openai pydantic httpx
 
       - name: Run E2E tests
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
 
           providers:
             - type: openai
-              host: localhost
+              host: localhost:8443
               endpoint: ${{ secrets.OPENAI_HOST }}
               api_key: ${{ secrets.OPENAI_API_KEY }}
           EOF

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,6 +44,7 @@ jobs:
           cat > config.yml << EOF
           cert_file: $(pwd)/fullchain.pem
           private_key_file: $(pwd)/privkey.pem
+          https_port: 8443
 
           auth_keys:
             - ${AUTH_KEY}
@@ -63,7 +64,7 @@ jobs:
           ./target/release/openproxy start -c config.yml &
           sleep 3
           # Verify the server is running
-          curl -k https://localhost:443 || true
+          curl -k https://localhost:8443 || true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -75,7 +76,7 @@ jobs:
 
       - name: Run E2E tests
         env:
-          OPENAI_BASE_URL: https://localhost:443/v1
+          OPENAI_BASE_URL: https://localhost:8443/v1
           OPENAI_API_KEY: ${{ env.AUTH_KEY }}
           SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
           REQUESTS_CA_BUNDLE: ${{ github.workspace }}/fullchain.pem

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -1,0 +1,48 @@
+from typing import List
+
+from openai import OpenAI
+from pydantic import BaseModel
+
+
+class EntitiesModel(BaseModel):
+    attributes: List[str]
+    colors: List[str]
+    animals: List[str]
+
+
+client = OpenAI()
+
+with client.responses.stream(
+    model="gpt-4.1",
+    input=[
+        {"role": "system", "content": "Extract entities from the input text"},
+        {
+            "role": "user",
+            "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+        },
+    ],
+    text_format=EntitiesModel,
+) as stream:
+    for event in stream:
+        if event.type == "response.refusal.delta":
+            print(event.delta, end="")
+        elif event.type == "response.output_text.delta":
+            print(event.delta, end="")
+        elif event.type == "response.error":
+            print(event.error, end="")
+        elif event.type == "response.completed":
+            print("Completed")
+            # print(event.response.output)
+
+    final_response = stream.get_final_response()
+    print(final_response)
+
+    # Parse the output and validate animals
+    output_text = final_response.output[0].content[0].text
+    result = EntitiesModel.model_validate_json(output_text)
+    animals_lower = [a.lower() for a in result.animals]
+
+    assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+    assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+
+    print("✓ All assertions passed!")

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import httpx
 from openai import OpenAI
 from pydantic import BaseModel
 
@@ -10,7 +11,8 @@ class EntitiesModel(BaseModel):
     animals: List[str]
 
 
-client = OpenAI()
+# Force HTTP/1.1 to avoid HTTP/2 protocol issues
+client = OpenAI(http_client=httpx.Client(http2=False))
 
 with client.responses.stream(
     model="gpt-4.1",

--- a/e2e/test.py
+++ b/e2e/test.py
@@ -11,40 +11,54 @@ class EntitiesModel(BaseModel):
     animals: List[str]
 
 
-# Force HTTP/1.1 to avoid HTTP/2 protocol issues
-client = OpenAI(http_client=httpx.Client(http2=False))
+def run_test(client: OpenAI, protocol: str):
+    print(f"\n{'='*50}")
+    print(f"Testing with {protocol}")
+    print('='*50)
 
-with client.responses.stream(
-    model="gpt-4.1",
-    input=[
-        {"role": "system", "content": "Extract entities from the input text"},
-        {
-            "role": "user",
-            "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
-        },
-    ],
-    text_format=EntitiesModel,
-) as stream:
-    for event in stream:
-        if event.type == "response.refusal.delta":
-            print(event.delta, end="")
-        elif event.type == "response.output_text.delta":
-            print(event.delta, end="")
-        elif event.type == "response.error":
-            print(event.error, end="")
-        elif event.type == "response.completed":
-            print("Completed")
-            # print(event.response.output)
+    with client.responses.stream(
+        model="gpt-4.1",
+        input=[
+            {"role": "system", "content": "Extract entities from the input text"},
+            {
+                "role": "user",
+                "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+            },
+        ],
+        text_format=EntitiesModel,
+    ) as stream:
+        for event in stream:
+            if event.type == "response.refusal.delta":
+                print(event.delta, end="")
+            elif event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.error":
+                print(event.error, end="")
+            elif event.type == "response.completed":
+                print("Completed")
 
-    final_response = stream.get_final_response()
-    print(final_response)
+        final_response = stream.get_final_response()
+        print(final_response)
 
-    # Parse the output and validate animals
-    output_text = final_response.output[0].content[0].text
-    result = EntitiesModel.model_validate_json(output_text)
-    animals_lower = [a.lower() for a in result.animals]
+        # Parse the output and validate animals
+        output_text = final_response.output[0].content[0].text
+        result = EntitiesModel.model_validate_json(output_text)
+        animals_lower = [a.lower() for a in result.animals]
 
-    assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
-    assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+        assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+        assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
 
-    print("✓ All assertions passed!")
+        print(f"✓ {protocol} test passed!")
+
+
+# Test with HTTP/1.1
+client_http1 = OpenAI(http_client=httpx.Client(http2=False))
+run_test(client_http1, "HTTP/1.1")
+
+# Test with HTTP/2
+client_http2 = OpenAI(http_client=httpx.Client(http2=True))
+run_test(client_http2, "HTTP/2")
+
+print("\n" + "="*50)
+print("✓ All tests passed!")
+print("="*50)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -491,6 +491,23 @@ pub(crate) fn split_host_path(host: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Strip port from host string (e.g., "localhost:8443" -> "localhost")
+#[inline]
+pub(crate) fn strip_port(host: &str) -> &str {
+    // Handle IPv6 addresses like [::1]:8080
+    if let Some(bracket_idx) = host.rfind(']') {
+        if let Some(colon_idx) = host[bracket_idx..].find(':') {
+            return &host[..bracket_idx + colon_idx];
+        }
+        return host;
+    }
+    // Handle regular host:port
+    if let Some(colon_idx) = host.rfind(':') {
+        return &host[..colon_idx];
+    }
+    host
+}
+
 pub(crate) fn get_req_path(header: &str) -> Range<usize> {
     // Extract URL part (between first and second space)
     let (url_start, url_end) = if let Some(first_whitespace_idx) = header.find(' ') {


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for E2E tests
- Generate self-signed certificates and random auth keys for testing
- Configure OpenAI provider using `OPENAI_HOST` and `OPENAI_API_KEY` secrets
- Add Python test script with streaming response validation (validates animals list contains fox and dog)

## Test plan
- [x] Configure `OPENAI_HOST` and `OPENAI_API_KEY` secrets in GitHub repository settings
- [x] Manually trigger workflow via `workflow_dispatch` to verify E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)