### PR TITLE
feat: add HTTP (non-TLS) E2E testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,6 +45,7 @@ jobs:
           cert_file: $(pwd)/fullchain.pem
           private_key_file: $(pwd)/privkey.pem
           https_port: 8443
+          http_port: 8080
 
           auth_keys:
             - ${AUTH_KEY}
@@ -52,6 +53,10 @@ jobs:
           providers:
             - type: openai
               host: localhost:8443
+              endpoint: ${{ secrets.OPENAI_HOST }}
+              api_key: ${{ secrets.OPENAI_API_KEY }}
+            - type: openai
+              host: localhost:8080
               endpoint: ${{ secrets.OPENAI_HOST }}
               api_key: ${{ secrets.OPENAI_API_KEY }}
           EOF
@@ -66,8 +71,9 @@ jobs:
         run: |
           ./target/release/openproxy start -c config.yml &
           sleep 3
-          # Verify the server is running
+          # Verify the servers are running
           curl -k https://localhost:8443 || true
+          curl http://localhost:8080 || true
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -77,7 +83,7 @@ jobs:
       - name: Install Python dependencies
         run: pip install openai pydantic "httpx[http2]"
 
-      - name: Run E2E tests
+      - name: Run HTTPS E2E tests
         env:
           OPENAI_BASE_URL: https://localhost:8443/v1
           OPENAI_API_KEY: ${{ env.AUTH_KEY }}
@@ -85,4 +91,12 @@ jobs:
           REQUESTS_CA_BUNDLE: ${{ github.workspace }}/fullchain.pem
         run: |
           cd e2e
-          python test.py
+          python test_https.py
+
+      - name: Run HTTP E2E tests
+        env:
+          OPENAI_BASE_URL: http://localhost:8080/v1
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+        run: |
+          cd e2e
+          python test_http.py

--- a/e2e/test_https.py
+++ b/e2e/test_https.py
@@ -13,7 +13,7 @@ class EntitiesModel(BaseModel):
 
 def run_test(client: OpenAI, protocol: str):
     print(f"\n{'='*50}")
-    print(f"Testing with {protocol}")
+    print(f"Testing HTTPS with {protocol}")
     print('='*50)
 
     with client.responses.stream(
@@ -48,7 +48,7 @@ def run_test(client: OpenAI, protocol: str):
         assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
         assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
 
-        print(f"✓ {protocol} test passed!")
+        print(f"✓ HTTPS + {protocol} test passed!")
 
 
 # Test with HTTP/1.1
@@ -60,5 +60,5 @@ client_http2 = OpenAI(http_client=httpx.Client(http2=True))
 run_test(client_http2, "HTTP/2")
 
 print("\n" + "="*50)
-print("✓ All tests passed!")
+print("✓ All HTTPS tests passed!")
 print("="*50)


### PR DESCRIPTION
## Summary
- Split `test.py` into `test_https.py` and `test_http.py` for better organization
- Add `http_port: 8080` configuration for plain HTTP testing
- Add separate provider configuration for HTTP endpoint
- Run both HTTPS and HTTP tests in CI workflow

## Test plan
- [x] Verify HTTPS E2E tests pass (HTTP/1.1 and HTTP/2)
- [x] Verify HTTP E2E tests pass (plain HTTP without TLS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)