### PR TITLE
Harden listener startup and pool safety

### DIFF
--- a/e2e/test_http.py
+++ b/e2e/test_http.py
@@ -85,6 +85,98 @@ run_test(client)
 
 test_no_provider_found_http()
 
+
+def test_invalid_host_header_http():
+    """Test various invalid or edge-case Host headers don't cause panics."""
+    print(f"\n{'='*50}")
+    print("Testing HTTP invalid/edge-case Host headers")
+    print('='*50)
+
+    base_url = os.environ["OPENAI_BASE_URL"]
+    api_key = os.environ["OPENAI_API_KEY"]
+
+    test_cases = [
+        ("Empty Host", ""),
+        ("Short Host (1 char)", "a"),
+        ("Short Host (5 chars)", "abcde"),
+        ("Whitespace only", "   "),
+        ("Unicode host", "测试.local"),
+    ]
+
+    with httpx.Client(base_url=base_url, http2=False, timeout=10) as client:
+        for name, host_value in test_cases:
+            print(f"  Testing: {name}")
+            try:
+                resp = client.get(
+                    "/models",
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Host": host_value,
+                    },
+                )
+                # We expect 404 (no provider found) or 400 (bad request), but no 500 or crash
+                assert resp.status_code in [400, 404], f"Unexpected status {resp.status_code} for {name}"
+                print(f"    -> Status: {resp.status_code} (OK)")
+            except httpx.RequestError as e:
+                # Connection errors are acceptable for some edge cases
+                print(f"    -> Connection error (acceptable): {e}")
+
+    print("\u2713 HTTP invalid Host header tests passed!")
+
+
+def test_connection_reuse_http():
+    """Test that connection pooling works correctly with keep-alive."""
+    print(f"\n{'='*50}")
+    print("Testing HTTP connection reuse (keep-alive)")
+    print('='*50)
+
+    base_url = os.environ["OPENAI_BASE_URL"]
+    api_key = os.environ["OPENAI_API_KEY"]
+
+    # Use a single client for multiple requests to test connection reuse
+    with httpx.Client(base_url=base_url, http2=False) as client:
+        for i in range(3):
+            resp = client.get(
+                "/v1/models",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                },
+            )
+            print(f"  Request {i+1}: Status {resp.status_code}")
+            # Accept either 200 (success) or 404 (no matching provider for this path)
+            assert resp.status_code in [200, 404], f"Unexpected status: {resp.status_code}"
+
+    print("\u2713 HTTP connection reuse test passed!")
+
+
+def test_bad_request_handling_http():
+    """Test that bad requests are handled gracefully."""
+    print(f"\n{'='*50}")
+    print("Testing HTTP bad request handling")
+    print('='*50)
+
+    base_url = os.environ["OPENAI_BASE_URL"]
+
+    with httpx.Client(base_url=base_url, http2=False, timeout=10) as client:
+        # Request without required headers
+        try:
+            resp = client.get(
+                "/models",
+                # No Authorization header, minimal request
+            )
+            # Should get 400, 401, or 404 depending on validation order
+            print(f"  Status: {resp.status_code}")
+            assert resp.status_code in [400, 401, 404], f"Unexpected status: {resp.status_code}"
+        except httpx.RequestError as e:
+            print(f"  Connection error (acceptable): {e}")
+
+    print("\u2713 HTTP bad request handling test passed!")
+
+
+test_invalid_host_header_http()
+test_connection_reuse_http()
+test_bad_request_handling_http()
+
 print("\n" + "="*50)
 print("\u2713 All HTTP tests passed!")
 print("="*50)

--- a/e2e/test_http.py
+++ b/e2e/test_http.py
@@ -100,7 +100,8 @@ def test_invalid_host_header_http():
         ("Short Host (1 char)", "a"),
         ("Short Host (5 chars)", "abcde"),
         ("Whitespace only", "   "),
-        ("Unicode host", "测试.local"),
+        # Note: Unicode hosts are rejected by httpx client before reaching server
+        ("Numeric host", "12345"),
     ]
 
     with httpx.Client(base_url=base_url, http2=False, timeout=10) as client:
@@ -117,9 +118,9 @@ def test_invalid_host_header_http():
                 # We expect 404 (no provider found) or 400 (bad request), but no 500 or crash
                 assert resp.status_code in [400, 404], f"Unexpected status {resp.status_code} for {name}"
                 print(f"    -> Status: {resp.status_code} (OK)")
-            except httpx.RequestError as e:
-                # Connection errors are acceptable for some edge cases
-                print(f"    -> Connection error (acceptable): {e}")
+            except (httpx.RequestError, ValueError) as e:
+                # Connection errors or invalid header errors are acceptable for some edge cases
+                print(f"    -> Client error (acceptable): {e}")
 
     print("\u2713 HTTP invalid Host header tests passed!")
 

--- a/e2e/test_https.py
+++ b/e2e/test_https.py
@@ -107,7 +107,8 @@ def test_invalid_host_header_https_http1():
         ("Short Host (1 char)", "a"),
         ("Short Host (5 chars)", "abcde"),
         ("Whitespace only", "   "),
-        ("Unicode host", "测试.local"),
+        # Note: Unicode hosts are rejected by httpx client before reaching server
+        ("Numeric host", "12345"),
     ]
 
     with httpx.Client(base_url=base_url, http2=False, verify=ssl_cert, timeout=10) as client:
@@ -124,9 +125,9 @@ def test_invalid_host_header_https_http1():
                 # We expect 404 (no provider found) or 400 (bad request), but no 500 or crash
                 assert resp.status_code in [400, 404], f"Unexpected status {resp.status_code} for {name}"
                 print(f"    -> Status: {resp.status_code} (OK)")
-            except httpx.RequestError as e:
-                # Connection errors are acceptable for some edge cases
-                print(f"    -> Connection error (acceptable): {e}")
+            except (httpx.RequestError, ValueError) as e:
+                # Connection errors or invalid header errors are acceptable for some edge cases
+                print(f"    -> Client error (acceptable): {e}")
 
     print("\u2713 HTTPS HTTP/1.1 invalid Host header tests passed!")
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -857,6 +857,36 @@ mod tests {
     }
 
     #[test]
+    fn test_get_host_boundary_checks() {
+        // Test empty input - should not panic
+        assert_eq!(get_host(Some(b"")), Some(""));
+
+        // Test input shorter than "Host: " prefix (6 chars)
+        assert_eq!(get_host(Some(b"H")), Some("H"));
+        assert_eq!(get_host(Some(b"Ho")), Some("Ho"));
+        assert_eq!(get_host(Some(b"Hos")), Some("Hos"));
+        assert_eq!(get_host(Some(b"Host")), Some("Host"));
+        assert_eq!(get_host(Some(b"Host:")), Some("Host:"));
+
+        // Test input exactly the length of "Host: " prefix (6 chars)
+        assert_eq!(get_host(Some(b"Host: ")), Some(""));
+
+        // Test with partial prefix match but shorter
+        assert_eq!(get_host(Some(b"host")), Some("host"));
+        assert_eq!(get_host(Some(b"HOST")), Some("HOST"));
+
+        // Test with whitespace only
+        assert_eq!(get_host(Some(b"   ")), Some("   "));
+
+        // Test with only newlines
+        assert_eq!(get_host(Some(b"\r\n")), Some("\r\n"));
+
+        // Test with mixed case prefix that matches
+        assert_eq!(get_host(Some(b"HOST: upper.com")), Some("upper.com"));
+        assert_eq!(get_host(Some(b"HoSt: mixed.com")), Some("mixed.com"));
+    }
+
+    #[test]
     fn test_read_state_copy_clone() {
         let state = ReadState::Start;
         let state_copy = state;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -471,10 +471,9 @@ impl<'a> Payload<'a> {
 #[inline]
 fn get_host(header: Option<&[u8]>) -> Option<&str> {
     header
-        .map(|header| std::str::from_utf8(header).ok())
-        .flatten()
+        .and_then(|header| std::str::from_utf8(header).ok())
         .map(|host| {
-            if host[..HEADER_HOST.len()].eq_ignore_ascii_case(HEADER_HOST) {
+            if host.len() >= HEADER_HOST.len() && host[..HEADER_HOST.len()].eq_ignore_ascii_case(HEADER_HOST) {
                 &host[HEADER_HOST.len()..]
             } else {
                 host

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,14 @@ use tokio::net::TcpListener;
 use worker::{Conn, Worker};
 
 /// Start the proxy server with the configured listeners
+///
+/// # Errors
+///
+/// Returns an error if the listener fails to bind to the configured port.
+/// This can happen if:
+/// - The port is already in use
+/// - The process lacks permission to bind to the port
+/// - The address is invalid
 #[must_use = "this `Result` must be handled to detect listener bind failures"]
 pub async fn serve(enable_health_check: bool) -> Result<(), Error> {
     let executor = Arc::new(Executor::new(Pool::new()));
@@ -418,4 +426,45 @@ pub async fn serve(enable_health_check: bool) -> Result<(), Error> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_invalid_server_name() {
+        let err = Error::InvalidServerName("invalid.endpoint".to_string());
+        assert_eq!(err.to_string(), "Invalid server name: invalid.endpoint");
+
+        // Verify the error contains the problematic endpoint name
+        let err = Error::InvalidServerName("my-custom-endpoint:443".to_string());
+        assert!(err.to_string().contains("my-custom-endpoint:443"));
+    }
+
+    #[test]
+    fn test_error_display() {
+        // Test all error variants have proper Display impl
+        let io_err = Error::IO(std::io::Error::new(std::io::ErrorKind::Other, "test"));
+        assert!(io_err.to_string().contains("IO error"));
+
+        let header_err = Error::HeaderTooLarge;
+        assert_eq!(header_err.to_string(), "Header too large");
+
+        let invalid_header = Error::InvalidHeader;
+        assert_eq!(invalid_header.to_string(), "Invalid header");
+
+        let no_provider = Error::NoProviderFound;
+        assert_eq!(no_provider.to_string(), "No provider found");
+    }
+
+    #[test]
+    fn test_error_from_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "refused");
+        let err: Error = io_err.into();
+        match err {
+            Error::IO(e) => assert_eq!(e.kind(), std::io::ErrorKind::ConnectionRefused),
+            _ => panic!("Expected IO error"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,7 @@ use tokio::net::TcpListener;
 use worker::{Conn, Worker};
 
 /// Start the proxy server with the configured listeners
+#[must_use = "this `Result` must be handled to detect listener bind failures"]
 pub async fn serve(enable_health_check: bool) -> Result<(), Error> {
     let executor = Arc::new(Executor::new(Pool::new()));
     let (https_port, http_port) = {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,6 +345,9 @@ pub enum Error {
     #[error("Invalid header")]
     InvalidHeader,
 
+    #[error("Invalid server name: {0}")]
+    InvalidServerName(String),
+
     #[error("No provider found")]
     NoProviderFound,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,9 @@ async fn start(
     enable_health_check: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     openproxy::load_config(&config, true).await?;
-    openproxy::serve(enable_health_check).await;
+    openproxy::serve(enable_health_check)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
     let mut signals =
         SignalsInfo::<SignalOnly>::new([signal::SIGTERM, signal::SIGINT, signal::SIGHUP])?;
     for signal in &mut signals {

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -536,7 +536,7 @@ impl ConnTrait for Conn {
             let server_name = endpoint
                 .clone()
                 .try_into()
-                .map_err(|_| Error::InvalidHeader)?;
+                .map_err(|_| Error::InvalidServerName(endpoint.clone()))?;
             let tls_stream = connector.connect(server_name, stream).await?;
             Ok(Self {
                 endpoint: endpoint.to_string(),

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -533,9 +533,11 @@ impl ConnTrait for Conn {
     ) -> Pin<Box<dyn Future<Output=Result<Self, Error>> + Send>> {
         let endpoint = endpoint.to_owned();
         Box::pin(async move {
-            let tls_stream = connector
-                .connect(endpoint.clone().try_into().unwrap(), stream)
-                .await?;
+            let server_name = endpoint
+                .clone()
+                .try_into()
+                .map_err(|_| Error::InvalidHeader)?;
+            let tls_stream = connector.connect(server_name, stream).await?;
             Ok(Self {
                 endpoint: endpoint.to_string(),
                 stream: Stream::Tls(tls_stream),


### PR DESCRIPTION
## Summary
- propagate listener bind failures instead of panicking and surface errors from serve
- make connection pool capacity increments atomic and rollback if push fails; validate server names and host parsing to avoid panics
- harden chunked/buffer reads to truncate on pending/error paths and prevent exposing uninitialized data

## Test plan
- [x] cargo test (96 tests passing)

### Unit tests added:
- **get_host boundary checks**: empty, short strings, edge cases to prevent panics
- **InvalidServerName error**: error type display and formatting
- **Pool tests**: 
  - Count consistency after add/get cycles
  - Zero and single capacity edge cases
  - Concurrent add and get operations
  - Multiple endpoints isolation
  - Entry API initialization
- **BufReader tests**: data preservation and buffer operations
- **ChunkedWriter tests**: empty/single byte/exact boundary inputs
- **ChunkedReader tests**: cleaning state transitions

### E2E tests added:
- Invalid/edge-case Host header handling (HTTP and HTTPS)
- Connection reuse with keep-alive
- Concurrent requests handling
- Bad request handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)