### PR TITLE
fix: resolve all cargo clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl Program {
             None
         };
 
-        let auth_keys = Arc::new(config.auth_keys.unwrap_or_else(Vec::new));
+        let auth_keys = Arc::new(config.auth_keys.unwrap_or_default());
         let mut providers = Vec::new();
         config.providers.sort_by_key(|provider| provider.host);
         for mut provider in config.providers {
@@ -188,7 +188,7 @@ impl Program {
                 } else {
                     provider_host == host || provider_host_without_port == host_without_port
                 };
-                selected.then(|| &**provider)
+                selected.then_some(&**provider)
             })
             .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,12 +29,12 @@ enum Command {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let openproxy = OpenProxy::parse();
-    match openproxy.command {
-        Some(Command::Start {
-                 config,
-                 enable_health_check,
-             }) => start(config, enable_health_check).await?,
-        _ => (),
+    if let Some(Command::Start {
+        config,
+        enable_health_check,
+    }) = openproxy.command
+    {
+        start(config, enable_health_check).await?
     }
     Ok(())
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -21,6 +21,7 @@ fn constant_time_eq(a: &str, b: &str) -> bool {
     a_bytes.len() == b_bytes.len() && bool::from(a_bytes.ct_eq(b_bytes))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn new_provider(
     kind: &str,
     host: &str,
@@ -132,10 +133,11 @@ pub trait Provider: Send + Sync {
     fn is_healthy(&self) -> bool;
     fn set_healthy(&self, healthy: bool);
 
+    #[allow(clippy::type_complexity)]
     fn health_check<'a: 'stream, 'stream>(
         &'a self,
         #[allow(unused)] stream: &'stream mut dyn AsyncReadWrite,
-    ) -> Pin<Box<dyn Future<Output=Result<(), Box<dyn std::error::Error>>> + Send + 'stream>>
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'stream>>
     {
         Box::pin(async move { Ok(()) })
     }
@@ -174,6 +176,7 @@ pub struct OpenAIProvider {
 }
 
 impl OpenAIProvider {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         host: &str,
         endpoint: &str,
@@ -188,7 +191,7 @@ impl OpenAIProvider {
         let host: Arc<str> = Arc::from(host);
         let endpoint: Arc<str> = Arc::from(endpoint);
         let server_name = rustls_pki_types::ServerName::try_from(endpoint.to_string())?;
-        let port = port.unwrap_or_else(|| if tls { 443 } else { 80 });
+        let port = port.unwrap_or(if tls { 443 } else { 80 });
         // Include port in Host header for non-standard ports (not 80 for HTTP, not 443 for HTTPS)
         let host_header = if (tls && port == 443) || (!tls && port == 80) {
             format!("Host: {}\r\n", endpoint)
@@ -259,7 +262,7 @@ impl Provider for OpenAIProvider {
     }
 
     fn has_auth_keys(&self) -> bool {
-        self.auth_keys.len() > 0 || self.provider_auth_keys.is_some()
+        !self.auth_keys.is_empty() || self.provider_auth_keys.is_some()
     }
 
     fn weight(&self) -> f64 {
@@ -309,10 +312,11 @@ impl Provider for OpenAIProvider {
         self.is_healthy.store(healthy, Ordering::SeqCst)
     }
 
+    #[allow(clippy::type_complexity)]
     fn health_check<'a: 'stream, 'stream>(
         &'a self,
         stream: &'stream mut dyn AsyncReadWrite,
-    ) -> Pin<Box<dyn Future<Output=Result<(), Box<dyn std::error::Error>>> + Send + 'stream>>
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'stream>>
     {
         if let Some(ref cfg) = self.health_check_config {
             Box::pin(health_check(
@@ -349,6 +353,7 @@ pub struct GeminiProvider {
 }
 
 impl GeminiProvider {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         host: &str,
         endpoint: &str,
@@ -366,7 +371,7 @@ impl GeminiProvider {
         let host: Arc<str> = Arc::from(host);
         let endpoint: Arc<str> = Arc::from(endpoint);
         let server_name = rustls_pki_types::ServerName::try_from(endpoint.to_string())?;
-        let port = port.unwrap_or_else(|| if tls { 443 } else { 80 });
+        let port = port.unwrap_or(if tls { 443 } else { 80 });
         // Include port in Host header for non-standard ports
         let host_header = if (tls && port == 443) || (!tls && port == 80) {
             format!("Host: {}\r\n", endpoint)
@@ -435,7 +440,7 @@ impl Provider for GeminiProvider {
     }
 
     fn has_auth_keys(&self) -> bool {
-        self.auth_keys.len() > 0 || self.provider_auth_keys.is_some()
+        !self.auth_keys.is_empty() || self.provider_auth_keys.is_some()
     }
 
     fn weight(&self) -> f64 {
@@ -481,10 +486,7 @@ impl Provider for GeminiProvider {
         if let (_, Some(prefix)) = http::split_host_path(self.host()) {
             block_cow_str = replace_path(prefix, block_str);
         }
-        let Some(query_range) = http::get_auth_query_range(&block_cow_str, http::QUERY_KEY_KEY)
-        else {
-            return None;
-        };
+        let query_range = http::get_auth_query_range(&block_cow_str, http::QUERY_KEY_KEY)?;
         let mut rewritten = Vec::with_capacity(block_cow_str.len());
         rewritten.extend_from_slice(block_cow_str[..query_range.start].as_bytes());
         rewritten.extend_from_slice(self.api_key.as_bytes());
@@ -548,6 +550,7 @@ pub struct AnthropicProvider {
 }
 
 impl AnthropicProvider {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         host: &str,
         endpoint: &str,
@@ -565,7 +568,7 @@ impl AnthropicProvider {
         let host: Arc<str> = Arc::from(host);
         let endpoint: Arc<str> = Arc::from(endpoint);
         let server_name = rustls_pki_types::ServerName::try_from(endpoint.to_string())?;
-        let port = port.unwrap_or_else(|| if tls { 443 } else { 80 });
+        let port = port.unwrap_or(if tls { 443 } else { 80 });
         // Include port in Host header for non-standard ports
         let host_header = if (tls && port == 443) || (!tls && port == 80) {
             format!("Host: {}\r\n", endpoint)
@@ -634,7 +637,7 @@ impl Provider for AnthropicProvider {
     }
 
     fn has_auth_keys(&self) -> bool {
-        self.auth_keys.len() > 0 || self.provider_auth_keys.is_some()
+        !self.auth_keys.is_empty() || self.provider_auth_keys.is_some()
     }
 
     fn weight(&self) -> f64 {
@@ -684,10 +687,11 @@ impl Provider for AnthropicProvider {
         self.is_healthy.store(healthy, Ordering::SeqCst)
     }
 
+    #[allow(clippy::type_complexity)]
     fn health_check<'a: 'stream, 'stream>(
         &'a self,
         stream: &'stream mut dyn AsyncReadWrite,
-    ) -> Pin<Box<dyn Future<Output=Result<(), Box<dyn std::error::Error>>> + Send + 'stream>>
+    ) -> Pin<Box<dyn Future<Output = Result<(), Box<dyn std::error::Error>>> + Send + 'stream>>
     {
         if let Some(ref cfg) = self.health_check_config {
             Box::pin(health_check(
@@ -715,8 +719,7 @@ fn replace_path<'a>(prefix: &str, block_str: &'a str) -> Cow<'a, str> {
         &block_str[path_range.start..path_range.end]
     };
 
-    let modified_path = if path.starts_with(prefix) {
-        let remaining = &path[prefix.len()..];
+    let modified_path = if let Some(remaining) = path.strip_prefix(prefix) {
         if remaining.is_empty() {
             "/"
         } else {

--- a/src/websocket/mod.rs
+++ b/src/websocket/mod.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 
 /// Bidirectional copy between two streams
 /// This is used after WebSocket handshake to proxy data in both directions
@@ -48,6 +48,7 @@ pub fn check_websocket_response(response_line: &str) -> (u16, bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncReadExt;
 
     #[test]
     fn test_check_websocket_response_valid() {


### PR DESCRIPTION
## Summary

- Remove unused import `AsyncReadExt` in websocket/mod.rs (moved to test module)
- Fix `multiple_bound_locations` warning by consolidating trait bounds
- Replace `map().flatten()` patterns with `and_then()`
- Use `io::Error::other()` instead of `io::Error::new(ErrorKind::Other, ...)`
- Use `is_empty()` instead of `len() == 0` / `len() > 0`
- Collapse nested if/else-if blocks
- Fix `unnecessary_lazy_evaluations` (`unwrap_or_else` -> `unwrap_or`, `then` -> `then_some`)
- Replace manual `strip_prefix` patterns with `strip_prefix()` method
- Use `div_ceil()` for ceiling division
- Use iterator `enumerate()` instead of range loop with indexing
- Fix `unused_mut` warnings
- Fix `to_string_in_format_args` warnings (remove redundant `.to_string()` in format!)
- Fix `needless_as_bytes` warnings (use `.len()` directly on strings)
- Add `Default` impl for `Pool`
- Add `#[allow(clippy::...)]` attributes for intentional patterns:
  - `too_many_arguments` on provider constructors and websocket functions
  - `type_complexity` on health_check return types
  - `large_enum_variant` on Stream enum
  - `dead_code` on WebSocketUpgrade fields
- Fix `mismatched_lifetime_syntaxes` by adding explicit lifetime `'_`
- Replace single `match` with `if let` in main.rs

## Test plan

- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes all 111 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)