### PR TITLE
test: add e2e tests for host path prefix routing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -115,20 +115,13 @@ jobs:
             "    port: 9000" \
             "    tls: false" \
             "  # Providers with path prefix for host path routing tests" \
+            "  # Use unique host names to avoid conflicts with other providers" \
             "  - type: openai" \
-            "    host: localhost:8443/openai" \
+            "    host: path-test.local/openai" \
             "    endpoint: ${ENDPOINT}" \
             "    api_key: ${API_KEY}" \
             "  - type: openai" \
-            "    host: localhost:8080/openai" \
-            "    endpoint: ${ENDPOINT}" \
-            "    api_key: ${API_KEY}" \
-            "  - type: openai" \
-            "    host: localhost:8443/api/v1" \
-            "    endpoint: ${ENDPOINT}" \
-            "    api_key: ${API_KEY}" \
-            "  - type: openai" \
-            "    host: localhost:8080/api/v1" \
+            "    host: nested-path.local/api/v1" \
             "    endpoint: ${ENDPOINT}" \
             "    api_key: ${API_KEY}" \
             > config.yml

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -114,6 +114,23 @@ jobs:
             "    endpoint: localhost" \
             "    port: 9000" \
             "    tls: false" \
+            "  # Providers with path prefix for host path routing tests" \
+            "  - type: openai" \
+            "    host: localhost:8443/openai" \
+            "    endpoint: ${ENDPOINT}" \
+            "    api_key: ${API_KEY}" \
+            "  - type: openai" \
+            "    host: localhost:8080/openai" \
+            "    endpoint: ${ENDPOINT}" \
+            "    api_key: ${API_KEY}" \
+            "  - type: openai" \
+            "    host: localhost:8443/api/v1" \
+            "    endpoint: ${ENDPOINT}" \
+            "    api_key: ${API_KEY}" \
+            "  - type: openai" \
+            "    host: localhost:8080/api/v1" \
+            "    endpoint: ${ENDPOINT}" \
+            "    api_key: ${API_KEY}" \
             > config.yml
           cat config.yml
 
@@ -152,6 +169,18 @@ jobs:
         run: |
           cd e2e
           python test_http.py
+
+      - name: Run Host Path Prefix E2E tests (HTTPS)
+        env:
+          PROXY_HOST: localhost
+          PROXY_HTTPS_PORT: 8443
+          PROXY_HTTP_PORT: 8080
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
+          REQUESTS_CA_BUNDLE: ${{ github.workspace }}/fullchain.pem
+        run: |
+          cd e2e
+          python test_host_path.py
 
       - name: Start WebSocket echo server
         run: |

--- a/e2e/test_host_path.py
+++ b/e2e/test_host_path.py
@@ -1,0 +1,363 @@
+"""
+E2E tests for host path prefix routing.
+
+This tests the scenario where providers are configured with a path prefix in the host,
+e.g., `host: localhost/openai`. The proxy should:
+1. Match requests based on both host and path prefix
+2. Strip the path prefix before forwarding to the backend
+
+Test configuration in e2e.yml:
+  - host: localhost:8443/openai -> routes /openai/* requests
+  - host: localhost:8443/api/v1 -> routes /api/v1/* requests
+"""
+
+from typing import List
+import httpx
+import os
+
+from openai import OpenAI
+from pydantic import BaseModel
+
+
+class EntitiesModel(BaseModel):
+    attributes: List[str]
+    colors: List[str]
+    animals: List[str]
+
+
+def get_proxy_config():
+    """Get proxy configuration from environment variables."""
+    host = os.environ.get("PROXY_HOST", "localhost")
+    https_port = os.environ.get("PROXY_HTTPS_PORT", "8443")
+    http_port = os.environ.get("PROXY_HTTP_PORT", "8080")
+    api_key = os.environ["OPENAI_API_KEY"]
+    ssl_cert = os.environ.get("SSL_CERT_FILE")
+    return {
+        "host": host,
+        "https_port": https_port,
+        "http_port": http_port,
+        "api_key": api_key,
+        "ssl_cert": ssl_cert,
+    }
+
+
+def test_host_path_prefix_https_http1():
+    """Test host path prefix routing over HTTPS with HTTP/1.1."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTPS + HTTP/1.1 + /openai prefix")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    # Use the /openai path prefix - requests to /openai/v1/* should be routed
+    # and the /openai prefix should be stripped, so backend receives /v1/*
+    base_url = f"https://{config['host']}:{config['https_port']}/openai/v1"
+
+    client = OpenAI(
+        base_url=base_url,
+        api_key=config["api_key"],
+        http_client=httpx.Client(http2=False, verify=config["ssl_cert"]),
+    )
+
+    with client.responses.stream(
+        model="gpt-4.1",
+        input=[
+            {"role": "system", "content": "Extract entities from the input text"},
+            {
+                "role": "user",
+                "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+            },
+        ],
+        text_format=EntitiesModel,
+    ) as stream:
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.completed":
+                print("\nCompleted")
+
+        final_response = stream.get_final_response()
+        output_text = final_response.output[0].content[0].text
+        result = EntitiesModel.model_validate_json(output_text)
+        animals_lower = [a.lower() for a in result.animals]
+
+        assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+        assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+
+    print("\u2713 HTTPS + HTTP/1.1 + /openai prefix test passed!")
+
+
+def test_host_path_prefix_https_http2():
+    """Test host path prefix routing over HTTPS with HTTP/2."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTPS + HTTP/2 + /openai prefix")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    base_url = f"https://{config['host']}:{config['https_port']}/openai/v1"
+
+    client = OpenAI(
+        base_url=base_url,
+        api_key=config["api_key"],
+        http_client=httpx.Client(http2=True, verify=config["ssl_cert"]),
+    )
+
+    with client.responses.stream(
+        model="gpt-4.1",
+        input=[
+            {"role": "system", "content": "Extract entities from the input text"},
+            {
+                "role": "user",
+                "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+            },
+        ],
+        text_format=EntitiesModel,
+    ) as stream:
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.completed":
+                print("\nCompleted")
+
+        final_response = stream.get_final_response()
+        output_text = final_response.output[0].content[0].text
+        result = EntitiesModel.model_validate_json(output_text)
+        animals_lower = [a.lower() for a in result.animals]
+
+        assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+        assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+
+    print("\u2713 HTTPS + HTTP/2 + /openai prefix test passed!")
+
+
+def test_host_path_prefix_http():
+    """Test host path prefix routing over HTTP."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTP + /openai prefix")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    base_url = f"http://{config['host']}:{config['http_port']}/openai/v1"
+
+    client = OpenAI(
+        base_url=base_url,
+        api_key=config["api_key"],
+        http_client=httpx.Client(http2=False),
+    )
+
+    with client.responses.stream(
+        model="gpt-4.1",
+        input=[
+            {"role": "system", "content": "Extract entities from the input text"},
+            {
+                "role": "user",
+                "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+            },
+        ],
+        text_format=EntitiesModel,
+    ) as stream:
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.completed":
+                print("\nCompleted")
+
+        final_response = stream.get_final_response()
+        output_text = final_response.output[0].content[0].text
+        result = EntitiesModel.model_validate_json(output_text)
+        animals_lower = [a.lower() for a in result.animals]
+
+        assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+        assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+
+    print("\u2713 HTTP + /openai prefix test passed!")
+
+
+def test_nested_path_prefix_https():
+    """Test nested path prefix routing (e.g., /api/v1) over HTTPS."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTPS + /api/v1 nested prefix")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    # Use nested path prefix /api/v1 - requests to /api/v1/v1/* should be routed
+    # The /api/v1 prefix should be stripped, so backend receives /v1/*
+    base_url = f"https://{config['host']}:{config['https_port']}/api/v1/v1"
+
+    client = OpenAI(
+        base_url=base_url,
+        api_key=config["api_key"],
+        http_client=httpx.Client(http2=True, verify=config["ssl_cert"]),
+    )
+
+    with client.responses.stream(
+        model="gpt-4.1",
+        input=[
+            {"role": "system", "content": "Extract entities from the input text"},
+            {
+                "role": "user",
+                "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+            },
+        ],
+        text_format=EntitiesModel,
+    ) as stream:
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.completed":
+                print("\nCompleted")
+
+        final_response = stream.get_final_response()
+        output_text = final_response.output[0].content[0].text
+        result = EntitiesModel.model_validate_json(output_text)
+        animals_lower = [a.lower() for a in result.animals]
+
+        assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+        assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+
+    print("\u2713 HTTPS + /api/v1 nested prefix test passed!")
+
+
+def test_nested_path_prefix_http():
+    """Test nested path prefix routing (e.g., /api/v1) over HTTP."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTP + /api/v1 nested prefix")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    base_url = f"http://{config['host']}:{config['http_port']}/api/v1/v1"
+
+    client = OpenAI(
+        base_url=base_url,
+        api_key=config["api_key"],
+        http_client=httpx.Client(http2=False),
+    )
+
+    with client.responses.stream(
+        model="gpt-4.1",
+        input=[
+            {"role": "system", "content": "Extract entities from the input text"},
+            {
+                "role": "user",
+                "content": "The quick brown fox jumps over the lazy dog with piercing blue eyes",
+            },
+        ],
+        text_format=EntitiesModel,
+    ) as stream:
+        for event in stream:
+            if event.type == "response.output_text.delta":
+                print(event.delta, end="")
+            elif event.type == "response.completed":
+                print("\nCompleted")
+
+        final_response = stream.get_final_response()
+        output_text = final_response.output[0].content[0].text
+        result = EntitiesModel.model_validate_json(output_text)
+        animals_lower = [a.lower() for a in result.animals]
+
+        assert "fox" in animals_lower, f"Expected 'fox' in animals, got: {result.animals}"
+        assert "dog" in animals_lower, f"Expected 'dog' in animals, got: {result.animals}"
+
+    print("\u2713 HTTP + /api/v1 nested prefix test passed!")
+
+
+def test_path_prefix_no_match_https():
+    """Test that requests with non-matching path prefix return 404."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTPS + non-matching path returns 404")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    base_url = f"https://{config['host']}:{config['https_port']}"
+
+    with httpx.Client(base_url=base_url, http2=False, verify=config["ssl_cert"]) as client:
+        # Request to /nonexistent/v1/models should not match any provider with path prefix
+        # The localhost:8443 provider without path prefix will match, so this should work
+        # But /nonexistent-provider/v1/models with a different Host header should fail
+        resp = client.get(
+            "/nonexistent-path-prefix/v1/models",
+            headers={
+                "Authorization": f"Bearer {config['api_key']}",
+                "Host": "some-random-host.local",
+            },
+        )
+
+        print(f"Status: {resp.status_code}")
+        print(f"Body: {resp.text[:200] if len(resp.text) > 200 else resp.text}")
+
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+        assert "no provider found" in resp.text.lower(), f"Unexpected body: {resp.text}"
+
+    print("\u2713 Non-matching path prefix returns 404 test passed!")
+
+
+def test_path_prefix_no_match_http():
+    """Test that requests with non-matching path prefix return 404 over HTTP."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: HTTP + non-matching path returns 404")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    base_url = f"http://{config['host']}:{config['http_port']}"
+
+    with httpx.Client(base_url=base_url, http2=False) as client:
+        resp = client.get(
+            "/nonexistent-path-prefix/v1/models",
+            headers={
+                "Authorization": f"Bearer {config['api_key']}",
+                "Host": "some-random-host.local",
+            },
+        )
+
+        print(f"Status: {resp.status_code}")
+        print(f"Body: {resp.text[:200] if len(resp.text) > 200 else resp.text}")
+
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+        assert "no provider found" in resp.text.lower(), f"Unexpected body: {resp.text}"
+
+    print("\u2713 HTTP non-matching path prefix returns 404 test passed!")
+
+
+def test_path_prefix_exact_match():
+    """Test that path prefix matching requires exact prefix match."""
+    print(f"\n{'='*60}")
+    print("Testing Host Path Prefix: exact prefix matching")
+    print("=" * 60)
+
+    config = get_proxy_config()
+    base_url = f"https://{config['host']}:{config['https_port']}"
+
+    with httpx.Client(base_url=base_url, http2=False, verify=config["ssl_cert"]) as client:
+        # /openai-extra should NOT match /openai prefix (requires / or end after prefix)
+        resp = client.get(
+            "/openai-extra/v1/models",
+            headers={
+                "Authorization": f"Bearer {config['api_key']}",
+                "Host": "some-unique-host-for-test.local",
+            },
+        )
+
+        print(f"Status: {resp.status_code}")
+
+        # This should return 404 because /openai-extra doesn't match /openai
+        # (the code checks that after the prefix there's either '/' or end of path)
+        assert resp.status_code == 404, f"Expected 404 for /openai-extra, got {resp.status_code}"
+
+    print("\u2713 Exact prefix matching test passed!")
+
+
+if __name__ == "__main__":
+    # Run HTTPS tests
+    test_host_path_prefix_https_http1()
+    test_host_path_prefix_https_http2()
+    test_nested_path_prefix_https()
+    test_path_prefix_no_match_https()
+    test_path_prefix_exact_match()
+
+    # Run HTTP tests
+    test_host_path_prefix_http()
+    test_nested_path_prefix_http()
+    test_path_prefix_no_match_http()
+
+    print("\n" + "=" * 60)
+    print("\u2713 All Host Path Prefix tests passed!")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

- Add comprehensive e2e tests for the host path prefix routing feature
- Test configurations like `host: localhost/openai` where requests to `/openai/*` are routed and the prefix is stripped before forwarding to the backend
- Cover multiple scenarios: HTTPS/HTTP, HTTP/1.1/HTTP/2, simple and nested prefixes, and error cases

## Test Cases

| Test Case | Protocol | Description |
|-----------|----------|-------------|
| `test_host_path_prefix_https_http1` | HTTPS + HTTP/1.1 | `/openai` prefix routing |
| `test_host_path_prefix_https_http2` | HTTPS + HTTP/2 | `/openai` prefix routing |
| `test_host_path_prefix_http` | HTTP | `/openai` prefix routing |
| `test_nested_path_prefix_https` | HTTPS | `/api/v1` nested prefix routing |
| `test_nested_path_prefix_http` | HTTP | `/api/v1` nested prefix routing |
| `test_path_prefix_no_match_https` | HTTPS | Non-matching path returns 404 |
| `test_path_prefix_no_match_http` | HTTP | Non-matching path returns 404 |
| `test_path_prefix_exact_match` | HTTPS | Validates exact prefix matching |

## Test plan

- [x] Tests created for host path prefix routing
- [x] CI runs the new tests automatically via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)