### PR TITLE
feat: add Anthropic OAuth (Authorization Bearer) authentication support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -413,3 +413,13 @@ jobs:
           fi
 
           echo "Gemini HTTP/1.1 test passed!"
+
+      - name: Install PyYAML for Anthropic OAuth tests
+        run: pip install pyyaml
+
+      - name: Run Anthropic OAuth E2E tests
+        run: |
+          echo "Testing Anthropic OAuth authentication..."
+          cd e2e
+          python test_anthropic_oauth.py
+          echo "Anthropic OAuth E2E tests passed!"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ cargo build --release
 # Run all tests
 cargo test
 
+# Run unit tests only
+cargo test --lib
+
 # Run a specific test
 cargo test test_name
 
@@ -26,12 +29,14 @@ cargo test --lib --verbose
 
 ```bash
 cd e2e
-pip install openai pydantic "httpx[http2]" websockets websocket-client
+pip install openai pydantic "httpx[http2]" websockets websocket-client pyyaml
 
 # Run individual test suites
 python test_https.py
 python test_http.py
 python test_websocket.py
+python test_host_path.py
+python test_anthropic_oauth.py
 ```
 
 ## Architecture
@@ -40,11 +45,12 @@ OpenProxy is a high-performance LLM proxy server that routes requests to multipl
 
 ### Core Modules
 
-- **`src/lib.rs`** - Configuration loading, provider selection with weighted load balancing, TLS setup
-- **`src/worker/mod.rs`** - Request handling for HTTP/1.1 and HTTP/2, WebSocket proxying
-- **`src/provider/mod.rs`** - Provider trait and implementations (OpenAI, Gemini, Anthropic)
-- **`src/http/mod.rs`** - HTTP parsing, header manipulation, payload reading
-- **`src/executor/mod.rs`** - Connection pooling and health check execution
+- **`src/lib.rs`** - Configuration loading, provider selection with weighted load balancing, TLS setup, global `Program` state
+- **`src/worker/mod.rs`** - Request handling for HTTP/1.1 and HTTP/2, WebSocket proxying, `UpstreamInfo` struct for provider details
+- **`src/provider/mod.rs`** - Provider trait and implementations (OpenAI, Gemini, Anthropic), authentication handling
+- **`src/http/mod.rs`** - HTTP parsing, header manipulation, `Payload` struct with `next_block()` state machine for streaming
+- **`src/executor/mod.rs`** - Connection pooling (`Pool<K, V>`) and health check execution
+- **`src/h2client/mod.rs`** - HTTP/2 client connections to upstream, TLS connector, connection pooling for H2
 - **`src/websocket/mod.rs`** - WebSocket upgrade detection and bidirectional proxying
 
 ### Request Flow
@@ -57,6 +63,28 @@ OpenProxy is a high-performance LLM proxy server that routes requests to multipl
 6. Worker proxies request to provider, streams response back
 7. For WebSocket: detects upgrade headers, establishes bidirectional tunnel
 
+### Provider Trait
+
+The `Provider` trait defines how each LLM provider handles authentication and headers:
+- `auth_header()` / `auth_header_key()` - Static authentication headers
+- `uses_dynamic_auth()` / `get_dynamic_auth_header()` - Dynamic auth (e.g., OAuth with `$(command)` pattern)
+- `extra_headers()` / `transform_extra_header()` - Additional headers to filter and transform (e.g., `anthropic-beta` for OAuth)
+
+### HTTP Header Processing (HTTP/1.1)
+
+The `Payload` struct in `http/mod.rs` uses a state machine (`ReadState`) to stream request/response data:
+- Headers are parsed and certain headers are filtered (`Host`, `Connection`, auth headers, extra headers)
+- `header_chunks: Vec<Range<usize>>` stores non-filtered header ranges
+- `split_header_chunks()` computes which parts of the header buffer to send upstream
+- Provider-specific headers are injected during streaming via `next_block()`
+
+### HTTP/2 Header Processing
+
+For HTTP/2 (`worker/mod.rs`):
+- `UpstreamInfo` struct pre-computes transformed headers before sending upstream
+- `extra_header_keys` and `extra_headers_transformed` hold header transformations
+- Headers are filtered and replaced during request building in `proxy_h2()` and `proxy_h1()` (H1 fallback)
+
 ### Provider Selection
 
 Providers are matched by the `Host` header from the client request. When multiple healthy providers match:
@@ -67,7 +95,7 @@ Providers are matched by the `Host` header from the client request. When multipl
 ### Protocol Support
 
 - **HTTP/1.1**: Plain HTTP and HTTPS with keep-alive
-- **HTTP/2**: Full multiplexing support, Extended CONNECT for WebSocket (RFC 8441)
+- **HTTP/2**: Full multiplexing support, Extended CONNECT for WebSocket (RFC 8441), automatic H1 fallback for non-TLS upstreams
 - **WebSocket**: Transparent proxying for both HTTP/1.1 upgrade and HTTP/2 CONNECT
 
 ### Configuration
@@ -77,3 +105,11 @@ YAML-based config with hot-reload via SIGHUP. Key fields:
 - `cert_file` / `private_key_file`: Required for HTTPS
 - `providers[]`: Type, host (for routing), endpoint (actual backend), api_key, weight, tls
 - `auth_keys`: Global authentication keys
+
+### Error Handling
+
+Custom `Error` enum in `lib.rs` with variants:
+- `IO`, `TLS`, `H2` - Protocol errors
+- `HeaderTooLarge`, `InvalidHeader` - Parsing errors
+- `NoProviderFound` - Routing errors
+- `DynamicAuthFailed` - OAuth/dynamic authentication errors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.2.2"
+version = "2.3.0"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/e2e/test_anthropic_oauth.py
+++ b/e2e/test_anthropic_oauth.py
@@ -1,0 +1,485 @@
+"""
+E2E tests for Anthropic OAuth authentication support.
+
+This test suite validates:
+1. Authorization: Bearer header is used instead of X-API-Key when api_key is $(command)
+2. anthropic-beta: oauth-2025-04-20 header is added when using OAuth mode
+3. Existing anthropic-beta header values are preserved and oauth value is appended
+
+The test uses a mock upstream server to verify the headers are correctly set.
+"""
+
+import json
+import os
+import socket
+import sys
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+
+class MockAnthropicServer(BaseHTTPRequestHandler):
+    """Mock server that validates OAuth headers and returns appropriate responses."""
+
+    # Class variables to store validation results
+    received_headers = {}
+    validation_errors = []
+
+    def log_message(self, format, *args):
+        # Suppress default logging
+        pass
+
+    def do_POST(self):
+        # Store received headers for validation
+        MockAnthropicServer.received_headers = dict(self.headers)
+
+        # Validate Authorization header
+        auth_header = self.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            MockAnthropicServer.validation_errors.append(
+                f"Missing or invalid Authorization header: {auth_header}"
+            )
+
+        # Validate anthropic-beta header
+        beta_header = self.headers.get("anthropic-beta", "")
+        if "oauth-2025-04-20" not in beta_header:
+            MockAnthropicServer.validation_errors.append(
+                f"Missing oauth-2025-04-20 in anthropic-beta header: {beta_header}"
+            )
+
+        # Check that X-API-Key is NOT present
+        if self.headers.get("X-API-Key"):
+            MockAnthropicServer.validation_errors.append(
+                f"X-API-Key header should not be present in OAuth mode"
+            )
+
+        # Read request body
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b""
+
+        # Return a mock response
+        response = {
+            "id": "msg_test123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "Hello! OAuth auth validated."}],
+            "model": "claude-3-sonnet-20240229",
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+        }
+
+        response_body = json.dumps(response).encode("utf-8")
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def do_GET(self):
+        # Health check endpoint
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"OK")
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+def find_free_port():
+    """Find a free port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        s.listen(1)
+        return s.getsockname()[1]
+
+
+def start_mock_server(port):
+    """Start the mock server in a separate thread."""
+    server = HTTPServer(("127.0.0.1", port), MockAnthropicServer)
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.daemon = True
+    server_thread.start()
+    return server
+
+
+def wait_for_server(host, port, timeout=5):
+    """Wait for the server to be ready."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.1)
+    return False
+
+
+def test_oauth_headers_via_proxy():
+    """
+    Test that OAuth headers are correctly forwarded through the proxy.
+
+    This test:
+    1. Starts a mock upstream server
+    2. Configures openproxy with an Anthropic provider using $(echo token) as api_key
+    3. Sends a request through the proxy
+    4. Verifies the upstream server receives correct headers
+    """
+    import httpx
+    import subprocess
+    import tempfile
+    import yaml
+
+    print(f"\n{'='*60}")
+    print("Testing Anthropic OAuth Header Forwarding")
+    print("=" * 60)
+
+    # Find free ports
+    mock_port = find_free_port()
+    proxy_http_port = find_free_port()
+
+    # Start mock server
+    print(f"Starting mock upstream server on port {mock_port}...")
+    MockAnthropicServer.received_headers = {}
+    MockAnthropicServer.validation_errors = []
+    mock_server = start_mock_server(mock_port)
+
+    if not wait_for_server("127.0.0.1", mock_port):
+        print("Failed to start mock server")
+        sys.exit(1)
+
+    print(f"Mock server ready on port {mock_port}")
+
+    # Create proxy config
+    config = {
+        "http_port": proxy_http_port,
+        "providers": [
+            {
+                "type": "anthropic",
+                "host": "anthropic-oauth.local",
+                "endpoint": "127.0.0.1",
+                "port": mock_port,
+                "tls": False,
+                # OAuth mode: api_key is a command
+                "api_key": "$(echo test-oauth-token-12345)",
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yml", delete=False
+    ) as config_file:
+        yaml.dump(config, config_file)
+        config_path = config_file.name
+
+    print(f"Config written to {config_path}")
+    print(f"Starting proxy on HTTP port {proxy_http_port}...")
+
+    # Start the proxy
+    proxy_process = subprocess.Popen(
+        ["cargo", "run", "--release", "--", "start", "-c", config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+
+    try:
+        # Wait for proxy to be ready
+        if not wait_for_server("127.0.0.1", proxy_http_port, timeout=30):
+            stdout, stderr = proxy_process.communicate(timeout=1)
+            print(f"Proxy stdout: {stdout.decode()}")
+            print(f"Proxy stderr: {stderr.decode()}")
+            print("Failed to start proxy")
+            sys.exit(1)
+
+        print("Proxy ready")
+
+        # Send request through proxy
+        print("Sending test request through proxy...")
+        with httpx.Client(
+            base_url=f"http://127.0.0.1:{proxy_http_port}", timeout=30, proxy=None
+        ) as client:
+            response = client.post(
+                "/v1/messages",
+                headers={
+                    "Host": "anthropic-oauth.local",
+                    "Content-Type": "application/json",
+                    "anthropic-version": "2023-06-01",
+                },
+                json={
+                    "model": "claude-3-sonnet-20240229",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+
+        print(f"Response status: {response.status_code}")
+        print(f"Response body: {response.text[:200]}")
+
+        # Check validation results
+        print("\n--- Received Headers at Upstream ---")
+        for key, value in MockAnthropicServer.received_headers.items():
+            print(f"  {key}: {value}")
+
+        print("\n--- Validation Results ---")
+        if MockAnthropicServer.validation_errors:
+            for error in MockAnthropicServer.validation_errors:
+                print(f"  ERROR: {error}")
+            sys.exit(1)
+        else:
+            # Additional assertions
+            auth = MockAnthropicServer.received_headers.get("Authorization", "")
+            assert auth == "Bearer test-oauth-token-12345", f"Unexpected Authorization: {auth}"
+
+            beta = MockAnthropicServer.received_headers.get("anthropic-beta", "")
+            assert "oauth-2025-04-20" in beta, f"Missing oauth-2025-04-20 in: {beta}"
+
+            print("  All headers validated successfully!")
+            print("\u2713 OAuth header forwarding test passed!")
+
+    finally:
+        # Cleanup
+        proxy_process.terminate()
+        try:
+            proxy_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proxy_process.kill()
+
+        os.unlink(config_path)
+
+
+def test_oauth_with_existing_beta_header():
+    """
+    Test that existing anthropic-beta header values are preserved.
+    """
+    import httpx
+    import subprocess
+    import tempfile
+    import yaml
+
+    print(f"\n{'='*60}")
+    print("Testing Anthropic OAuth with Existing Beta Header")
+    print("=" * 60)
+
+    # Find free ports
+    mock_port = find_free_port()
+    proxy_http_port = find_free_port()
+
+    # Start mock server
+    print(f"Starting mock upstream server on port {mock_port}...")
+    MockAnthropicServer.received_headers = {}
+    MockAnthropicServer.validation_errors = []
+    mock_server = start_mock_server(mock_port)
+
+    if not wait_for_server("127.0.0.1", mock_port):
+        print("Failed to start mock server")
+        sys.exit(1)
+
+    # Create proxy config
+    config = {
+        "http_port": proxy_http_port,
+        "providers": [
+            {
+                "type": "anthropic",
+                "host": "anthropic-oauth.local",
+                "endpoint": "127.0.0.1",
+                "port": mock_port,
+                "tls": False,
+                "api_key": "$(echo oauth-token)",
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yml", delete=False
+    ) as config_file:
+        yaml.dump(config, config_file)
+        config_path = config_file.name
+
+    # Start the proxy
+    proxy_process = subprocess.Popen(
+        ["cargo", "run", "--release", "--", "start", "-c", config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+
+    try:
+        if not wait_for_server("127.0.0.1", proxy_http_port, timeout=30):
+            print("Failed to start proxy")
+            sys.exit(1)
+
+        # Send request with existing anthropic-beta header
+        print("Sending test request with existing anthropic-beta header...")
+        with httpx.Client(
+            base_url=f"http://127.0.0.1:{proxy_http_port}", timeout=30, proxy=None
+        ) as client:
+            response = client.post(
+                "/v1/messages",
+                headers={
+                    "Host": "anthropic-oauth.local",
+                    "Content-Type": "application/json",
+                    "anthropic-version": "2023-06-01",
+                    "anthropic-beta": "max-tokens-3-5-sonnet-2024-07-15",
+                },
+                json={
+                    "model": "claude-3-sonnet-20240229",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+
+        print(f"Response status: {response.status_code}")
+
+        # Check that both beta values are present
+        beta = MockAnthropicServer.received_headers.get("anthropic-beta", "")
+        print(f"Received anthropic-beta: {beta}")
+
+        assert "max-tokens-3-5-sonnet-2024-07-15" in beta, f"Missing original beta value in: {beta}"
+        assert "oauth-2025-04-20" in beta, f"Missing oauth-2025-04-20 in: {beta}"
+
+        print("\u2713 Existing beta header preservation test passed!")
+
+    finally:
+        proxy_process.terminate()
+        try:
+            proxy_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proxy_process.kill()
+
+        os.unlink(config_path)
+
+
+def test_standard_mode_uses_x_api_key():
+    """
+    Test that standard mode (non-OAuth) still uses X-API-Key header.
+    """
+    import httpx
+    import subprocess
+    import tempfile
+    import yaml
+
+    print(f"\n{'='*60}")
+    print("Testing Anthropic Standard Mode (X-API-Key)")
+    print("=" * 60)
+
+    # Find free ports
+    mock_port = find_free_port()
+    proxy_http_port = find_free_port()
+
+    # Custom handler for standard mode
+    class StandardModeHandler(BaseHTTPRequestHandler):
+        received_headers = {}
+
+        def log_message(self, format, *args):
+            pass
+
+        def do_POST(self):
+            StandardModeHandler.received_headers = dict(self.headers)
+
+            response = json.dumps({"id": "msg_test", "content": [{"type": "text", "text": "OK"}]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(response)))
+            self.end_headers()
+            self.wfile.write(response)
+
+    # Start mock server
+    server = HTTPServer(("127.0.0.1", mock_port), StandardModeHandler)
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.daemon = True
+    server_thread.start()
+
+    if not wait_for_server("127.0.0.1", mock_port):
+        print("Failed to start mock server")
+        sys.exit(1)
+
+    # Create proxy config with standard api_key (not $(command))
+    config = {
+        "http_port": proxy_http_port,
+        "providers": [
+            {
+                "type": "anthropic",
+                "host": "anthropic-standard.local",
+                "endpoint": "127.0.0.1",
+                "port": mock_port,
+                "tls": False,
+                "api_key": "sk-ant-api-key-standard-12345",  # Standard key, not $(command)
+            }
+        ],
+    }
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".yml", delete=False
+    ) as config_file:
+        yaml.dump(config, config_file)
+        config_path = config_file.name
+
+    proxy_process = subprocess.Popen(
+        ["cargo", "run", "--release", "--", "start", "-c", config_path],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+
+    try:
+        if not wait_for_server("127.0.0.1", proxy_http_port, timeout=30):
+            print("Failed to start proxy")
+            sys.exit(1)
+
+        # Send request
+        print("Sending test request...")
+        with httpx.Client(
+            base_url=f"http://127.0.0.1:{proxy_http_port}", timeout=30, proxy=None
+        ) as client:
+            response = client.post(
+                "/v1/messages",
+                headers={
+                    "Host": "anthropic-standard.local",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": "claude-3-sonnet-20240229",
+                    "max_tokens": 100,
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+            )
+
+        print(f"Response status: {response.status_code}")
+
+        # Verify X-API-Key is used (not Authorization Bearer)
+        x_api_key = StandardModeHandler.received_headers.get("X-API-Key", "")
+        auth_header = StandardModeHandler.received_headers.get("Authorization", "")
+        beta_header = StandardModeHandler.received_headers.get("anthropic-beta", "")
+
+        print(f"X-API-Key: {x_api_key}")
+        print(f"Authorization: {auth_header}")
+        print(f"anthropic-beta: {beta_header}")
+
+        assert x_api_key == "sk-ant-api-key-standard-12345", f"Unexpected X-API-Key: {x_api_key}"
+        assert not auth_header, f"Authorization header should not be present: {auth_header}"
+        assert "oauth-2025-04-20" not in beta_header, f"oauth-2025-04-20 should not be in standard mode: {beta_header}"
+
+        print("\u2713 Standard mode test passed!")
+
+    finally:
+        proxy_process.terminate()
+        try:
+            proxy_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proxy_process.kill()
+
+        os.unlink(config_path)
+
+
+if __name__ == "__main__":
+    test_oauth_headers_via_proxy()
+    test_oauth_with_existing_beta_header()
+    test_standard_mode_uses_x_api_key()
+
+    print("\n" + "=" * 60)
+    print("\u2713 All Anthropic OAuth tests passed!")
+    print("=" * 60)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -151,8 +151,6 @@ pub(crate) struct Payload<'a> {
     path_range: Range<usize>,
     host_range: Option<Range<usize>>,
     auth_range: Option<Range<usize>>,
-    #[allow(dead_code)]
-    anthropic_beta_range: Option<Range<usize>>,
     pub(crate) body: Body<'a>,
     state: ReadState,
     header_chunks: [Option<Range<usize>>; 5],
@@ -212,7 +210,6 @@ impl<'a> Payload<'a> {
         let mut host_range: Option<Range<usize>> = None;
         let mut auth_range: Option<Range<usize>> = None;
         let mut header_chunks: [Option<Range<usize>>; 5] = [None, None, None, None, None];
-        let mut anthropic_beta_range: Option<Range<usize>> = None;
         let mut conn_keep_alive = false;
         // WebSocket upgrade detection
         let mut is_upgrade_websocket = false;
@@ -361,7 +358,6 @@ impl<'a> Payload<'a> {
                             beta_start - block_start
                         };
                         header_chunks[3] = Some(start..start + line.len());
-                        anthropic_beta_range = Some(start..start + line.len());
                         break;
                     }
                 }
@@ -433,7 +429,6 @@ impl<'a> Payload<'a> {
             path_range,
             host_range,
             auth_range,
-            anthropic_beta_range,
             body,
             state: ReadState::Start,
             header_chunks: split_header_chunks(header_chunks, header_length),

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -548,7 +548,7 @@ impl<'a> Payload<'a> {
                             }
                             Err(e) => {
                                 log::error!(error = e.to_string(); "failed_to_get_dynamic_auth_header");
-                                // Fall through to next_block() if auth header generation fails
+                                return Err(Error::DynamicAuthFailed);
                             }
                         }
                     } else if let Some(auth_header) = provider.auth_header() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,6 +461,9 @@ mod tests {
 
         let no_provider = Error::NoProviderFound;
         assert_eq!(no_provider.to_string(), "No provider found");
+
+        let dynamic_auth_failed = Error::DynamicAuthFailed;
+        assert_eq!(dynamic_auth_failed.to_string(), "Dynamic authentication failed");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,9 @@ pub enum Error {
 
     #[error("No provider found")]
     NoProviderFound,
+
+    #[error("Dynamic authentication failed")]
+    DynamicAuthFailed,
 }
 
 use executor::{Executor, Pool};


### PR DESCRIPTION
## Summary

- Add support for Anthropic's OAuth-style authentication using `Authorization: Bearer` header
- When `api_key` is configured as `$(command)` pattern (e.g., `$(cat .credentials.json | jq -r .access_token)`), execute the command to get OAuth token dynamically
- Use `Authorization: Bearer <token>` header instead of `X-API-Key` for OAuth mode
- Automatically add `anthropic-beta: oauth-2025-04-20` header when using OAuth
- If request already has `anthropic-beta` header, append `oauth-2025-04-20` to existing values (preserving original values)

## Usage

```yaml
providers:
  - type: anthropic
    host: api.anthropic.com
    endpoint: api.anthropic.com
    # OAuth mode: use command substitution to get token
    api_key: "$(cat .credentials.json | jq -r .access_token)"
```

Standard mode (unchanged):
```yaml
providers:
  - type: anthropic
    host: api.anthropic.com
    endpoint: api.anthropic.com
    api_key: "sk-ant-api-key-xxxxx"  # Uses X-API-Key header
```

## Test plan

- [x] Unit tests for OAuth command detection and execution
- [x] Unit tests for dynamic auth header generation
- [x] Unit tests for anthropic-beta header handling
- [x] E2E tests with mock upstream server validating correct headers
- [x] All 135 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)