### PR TITLE
docs: improve CLI help documentation with detailed descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,22 +5,89 @@ use signal_hook::consts::signal;
 use signal_hook::iterator::exfiltrator::SignalOnly;
 use signal_hook::iterator::SignalsInfo;
 
+const LONG_ABOUT: &str = "\
+OpenProxy is a high-performance LLM (Large Language Model) proxy server written \
+in Rust, designed to intelligently route requests between multiple LLM providers.
+
+FEATURES:
+  • Multi-Provider Support - Route requests to OpenAI, Gemini, and Anthropic APIs
+  • Weighted Load Balancing - Distribute traffic across providers based on weights
+  • Health Monitoring - Automatic health checks with failure recovery
+  • Connection Pooling - Efficient connection reuse for minimal latency
+  • Protocol Support - Full HTTP/1.1 and HTTP/2 with automatic negotiation
+  • WebSocket Support - Transparent proxying including OpenAI Realtime API
+  • OAuth Support - Dynamic auth with shell command execution for tokens
+  • Hot Reload - Update configuration via SIGHUP without restart
+
+ROUTING:
+  Requests are routed based on the 'Host' header. Configure each provider with
+  a unique host name, and clients specify which provider to use via this header.
+
+SIGNALS:
+  SIGTERM/SIGINT  Graceful shutdown
+  SIGHUP          Reload configuration without restart
+
+For more information, visit: https://github.com/x5iu/openproxy";
+
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(
+    name = "openproxy",
+    version,
+    about = "A high-performance LLM proxy server for OpenAI, Gemini, and Anthropic",
+    long_about = LONG_ABOUT,
+    after_help = "Use 'openproxy <command> --help' for more information about a command."
+)]
 struct OpenProxy {
     #[command(subcommand)]
     command: Option<Command>,
 }
 
+const START_LONG_ABOUT: &str = "\
+Start the OpenProxy server with the specified configuration file.
+
+The server will listen on the ports configured in the YAML config file:
+  • https_port - HTTPS with TLS (requires cert_file and private_key_file)
+  • http_port  - Plain HTTP without TLS (HTTP/1.1 only)
+
+At least one port must be configured. Both can be enabled simultaneously.
+
+EXAMPLES:
+  openproxy start -c config.yml
+  openproxy start -c config.yml --enable-health-check
+
+NOTE: HTTP or HTTPS mode is determined by the config file, not command-line args.
+  • Set 'https_port' in config for HTTPS (requires cert_file and private_key_file)
+  • Set 'http_port' in config for plain HTTP (no TLS certificates needed)
+
+CONFIG FILE FORMAT:
+  The configuration file uses YAML format. Required fields:
+    • providers[]  - List of LLM provider configurations
+    • https_port or http_port - At least one port must be specified
+
+  For HTTPS, also required:
+    • cert_file         - Path to TLS certificate (PEM format)
+    • private_key_file  - Path to TLS private key (PEM format)
+
+  See the project README for full configuration documentation.";
+
 #[derive(Subcommand)]
 enum Command {
     /// Start the proxy server
+    #[command(long_about = START_LONG_ABOUT)]
     Start {
-        /// Path to the config file
+        /// Path to the YAML configuration file
+        ///
+        /// The config file defines provider endpoints, authentication keys,
+        /// TLS certificates, ports, and health check settings.
         #[arg(short, long, value_name = "FILE")]
         config: PathBuf,
 
-        /// Enable provider health check
+        /// Enable automatic health checks for providers
+        ///
+        /// When enabled, the proxy periodically checks each provider's health
+        /// endpoint and excludes unhealthy providers from load balancing.
+        /// The check interval is configured via 'health_check_interval' in
+        /// the config file (default: 60 seconds).
         #[arg(long = "enable-health-check")]
         enable_health_check: bool,
     },


### PR DESCRIPTION
## Summary

- Add comprehensive help text for the `openproxy` command-line tool
- Add detailed `long_about` for main command describing features, routing, and signals
- Add `long_about` for `start` subcommand with usage examples and config file format info
- Add detailed help text for `--config` and `--enable-health-check` options

### Before
```
$ openproxy --help
A LLM Proxy

Usage: openproxy [COMMAND]

Commands:
  start  Start the proxy server
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

### After (`openproxy --help`)
```
OpenProxy is a high-performance LLM (Large Language Model) proxy server written in Rust, designed to intelligently route requests between multiple LLM providers.

FEATURES:
  • Multi-Provider Support - Route requests to OpenAI, Gemini, and Anthropic APIs
  • Weighted Load Balancing - Distribute traffic across providers based on weights
  ...

Usage: openproxy [COMMAND]

Commands:
  start  Start the proxy server
  help   Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help (see a summary with '-h')
  -V, --version  Print version

Use 'openproxy <command> --help' for more information about a command.
```

### After (`openproxy start --help`)
```
EXAMPLES:
  openproxy start -c config.yml
  openproxy start -c config.yml --enable-health-check

NOTE: HTTP or HTTPS mode is determined by the config file, not command-line args.
  • Set 'https_port' in config for HTTPS (requires cert_file and private_key_file)
  • Set 'http_port' in config for plain HTTP (no TLS certificates needed)
```

## Test plan

- [x] `cargo build --release` compiles successfully
- [x] `cargo test --lib` all 138 tests pass
- [x] `openproxy --help` displays detailed help
- [x] `openproxy start --help` displays detailed subcommand help

🤖 Generated with [Claude Code](https://claude.com/claude-code)