### PR TITLE
docs: remove fixed EXPOSE port and improve Docker documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ FROM ubuntu:22.04
 # Copy the binary from builder stage
 COPY --from=builder /usr/src/app/target/release/openproxy /usr/local/bin/openproxy
 
-# Expose port
-EXPOSE 443
+# Note: Port is determined by config file (https_port/http_port)
+# Map ports at runtime: docker run -p <host_port>:<container_port>
 
 # Run the application
 ENTRYPOINT ["/usr/local/bin/openproxy"]

--- a/README.md
+++ b/README.md
@@ -35,9 +35,20 @@ cargo build --release
 
 ```bash
 # Pull and run the pre-built image
+# Port mapping should match your config.yml (https_port/http_port)
 docker run -d \
   --name openproxy \
   -p 443:443 \
+  -v /path/to/config.yml:/config.yml \
+  -v /path/to/certificate.pem:/certs/certificate.pem \
+  -v /path/to/private-key.pem:/certs/private-key.pem \
+  x5iu/openproxy:latest
+
+# Example with custom ports (e.g., https_port: 8443, http_port: 8080 in config)
+docker run -d \
+  --name openproxy \
+  -p 8443:8443 \
+  -p 8080:8080 \
   -v /path/to/config.yml:/config.yml \
   -v /path/to/certificate.pem:/certs/certificate.pem \
   -v /path/to/private-key.pem:/certs/private-key.pem \


### PR DESCRIPTION
## Summary
- Remove hardcoded `EXPOSE 443` from Dockerfile since the actual port is determined by config file (`https_port`/`http_port`)
- Add comment in Dockerfile explaining port configuration
- Update README with port mapping instructions and custom port example

## Rationale
The `EXPOSE` directive in Docker is only documentation and doesn't actually control port binding. Since OpenProxy's port is configurable via `config.yml`, having a fixed `EXPOSE 443` could be misleading. Users should map ports at runtime based on their configuration.

## Test plan
- [x] Verify Dockerfile still builds correctly
- [x] Verify README documentation is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)