### PR TITLE
feat: add Linux amd64 binary build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,18 @@ jobs:
           git tag -a "$VERSION" -m "Release $VERSION"
           git push origin "$VERSION"
 
+      - name: Setup Rust
+        if: steps.check_version.outputs.should_release == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build Linux amd64 binary
+        if: steps.check_version.outputs.should_release == 'true'
+        run: |
+          cargo build --release
+          mkdir -p dist
+          cp target/release/openproxy dist/openproxy-linux-amd64
+          cd dist && tar -czvf openproxy-linux-amd64.tar.gz openproxy-linux-amd64
+
       - name: Setup Node.js
         if: steps.check_version.outputs.should_release == 'true'
         uses: actions/setup-node@v4
@@ -74,5 +86,7 @@ jobs:
           tag_name: ${{ steps.check_version.outputs.version }}
           body_path: release_notes.md
           generate_release_notes: false
+          files: |
+            dist/openproxy-linux-amd64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           CURRENT_TAG="${{ steps.check_version.outputs.version }}"
           PREV_TAG="${{ steps.check_version.outputs.latest_tag }}"
-          claude -p "Generate release notes for OpenProxy ${CURRENT_TAG} (a high-performance LLM proxy server that routes requests to multiple providers like OpenAI, Gemini, and Anthropic). Previous version: ${PREV_TAG}. Instructions: 1) Read the git commits between ${PREV_TAG} and ${CURRENT_TAG} using: git log ${PREV_TAG}..HEAD --oneline; 2) Output ONLY the release notes content in Markdown format, nothing else; 3) Do NOT include any preamble, explanation, or commentary about what you are doing; 4) Format: ## Summary, ## New Features, ## Bug Fixes, ## Breaking Changes (omit empty sections); 5) Be concise and professional." --output-format text > release_notes.md
+          claude --model opus -p "Generate release notes for OpenProxy ${CURRENT_TAG} (a high-performance LLM proxy server that routes requests to multiple providers like OpenAI, Gemini, and Anthropic). Previous version: ${PREV_TAG}. Instructions: 1) Read the git commits between ${PREV_TAG} and ${CURRENT_TAG} using: git log ${PREV_TAG}..HEAD --oneline; 2) Output ONLY the release notes content in Markdown format, nothing else; 3) Do NOT include any preamble, explanation, or commentary about what you are doing; 4) Format: ## Summary, ## New Features, ## Bug Fixes, ## Breaking Changes (omit empty sections); 5) Be concise and professional." --output-format text > release_notes.md
 
       - name: Create Release
         if: steps.check_version.outputs.should_release == 'true'


### PR DESCRIPTION
## Summary
- Add Linux amd64 binary build step to the release workflow
- Binary is packaged as `openproxy-linux-amd64.tar.gz` and uploaded to release assets

## Changes
- Setup Rust toolchain using `dtolnay/rust-toolchain@stable`
- Build release binary with `cargo build --release`
- Package binary into tar.gz archive
- Upload archive to GitHub release assets

## Test plan
- [ ] Verify workflow syntax is correct
- [ ] Test by bumping version in Cargo.toml and triggering a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)