### PR TITLE
fix: use cross for musl static linking to support older glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,16 @@ jobs:
         if: steps.check_version.outputs.should_release == 'true'
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Build Linux amd64 binary
+      - name: Install cross
+        if: steps.check_version.outputs.should_release == 'true'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build Linux amd64 binary (static linking with musl)
         if: steps.check_version.outputs.should_release == 'true'
         run: |
-          cargo build --release
+          cross build --release --target x86_64-unknown-linux-musl
           mkdir -p dist
-          cp target/release/openproxy dist/openproxy-linux-amd64
+          cp target/x86_64-unknown-linux-musl/release/openproxy dist/openproxy-linux-amd64
           cd dist && tar -czvf openproxy-linux-amd64.tar.gz openproxy-linux-amd64
 
       - name: Setup Node.js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "bytes",
  "clap",
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.5.1"
+version = "2.5.2"
 edition = "2021"
 description = "A LLM Proxy"
 


### PR DESCRIPTION
## Summary

- 使用 `cross` 工具代替直接的 cargo build 进行 musl 静态链接编译
- 解决在 Ubuntu 20.04 等旧系统上运行时报 `GLIBC_2.32 not found` 的问题

## 原因

当前 workflow 使用 `ubuntu-latest` (Ubuntu 22.04) 编译，生成的二进制文件链接了 GLIBC 2.32+，无法在 GLIBC 2.31 的 Ubuntu 20.04 上运行。

## 解决方案

使用 `cross` 工具通过 Docker 容器进行 `x86_64-unknown-linux-musl` 目标编译，生成完全静态链接的二进制文件，不依赖系统 glibc。

🤖 Generated with [Claude Code](https://claude.com/claude-code)