### PR TITLE
fix: handle deleted executable path during hot upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.5.2"
+version = "2.5.3"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.5.2"
+version = "2.5.3"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,7 @@ async fn start(
 /// 1. Deleting the old binary
 /// 2. Downloading/copying a new binary to the same path
 /// 3. Sending SIGUSR2 to trigger the hot upgrade
+#[cfg(target_os = "linux")]
 fn resolve_exe_path(exe: PathBuf) -> PathBuf {
     let path_str = exe.to_string_lossy();
     if path_str.ends_with(" (deleted)") {
@@ -196,4 +197,10 @@ fn resolve_exe_path(exe: PathBuf) -> PathBuf {
     } else {
         exe
     }
+}
+
+/// On non-Linux platforms, return the path unchanged.
+#[cfg(not(target_os = "linux"))]
+fn resolve_exe_path(exe: PathBuf) -> PathBuf {
+    exe
 }


### PR DESCRIPTION
## Summary

- Fix hot upgrade failing with "No such file or directory" when replacing the binary by delete + download
- On Linux, `/proc/self/exe` returns path with " (deleted)" suffix when executable is deleted while running
- Strip the " (deleted)" suffix to find the new binary at the original path

## Problem

When performing a hot upgrade by:
1. Deleting the old `openproxy` binary
2. Downloading a new `openproxy` binary to the same path
3. Sending `kill -USR2` to trigger hot upgrade

The upgrade fails with:
```json
{"error":"No such file or directory (os error 2)","message":"hot_upgrade_spawn_failed",...}
```

## Root Cause

`std::env::current_exe()` reads `/proc/self/exe` on Linux. When the executable is deleted while the process is still running, this symlink resolves to something like `/path/to/openproxy (deleted)` instead of `/path/to/openproxy`.

Even though a new binary exists at the original path, `current_exe()` still returns the deleted path.

## Solution

Added `resolve_exe_path()` function that strips the " (deleted)" suffix from the path, allowing the hot upgrade to spawn the new binary at the original location.

## Test plan

- [x] `cargo build --release` succeeds
- [x] All 143 unit tests pass (`cargo test --lib`)
- [ ] Manual test: delete binary → download new binary → send SIGUSR2 → verify new process spawns

🤖 Generated with [Claude Code](https://claude.com/claude-code)