### PR TITLE
feat: add is_fallback support for provider selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.5.3"
+version = "2.6.0"
 dependencies = [
  "bytes",
  "clap",
@@ -659,15 +659,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.146"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
+checksum = "6af14725505314343e673e9ecb7cd7e8a36aa9791eb936235a3567cc31447ae4"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1227,3 +1227,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e404bcd8afdaf006e529269d3e85a743f9480c3cef60034d77860d02964f3ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.5.3"
+version = "2.6.0"
 edition = "2021"
 description = "A LLM Proxy"
 


### PR DESCRIPTION
## Summary
- Add `is_fallback` configuration option for providers to designate them as fallback/backup providers
- When `is_fallback=true`, the provider is only selected when no non-fallback providers are available
- Fallback providers are useful for configuring backup services that should only be used when primary providers are unhealthy

## Changes
- Add `is_fallback` field to `ProviderConfig` in `lib.rs`
- Add `is_fallback: bool` field and `is_fallback()` method to all provider types (OpenAI, Gemini, Anthropic)
- Update `select_provider()` to partition providers into non-fallback and fallback groups, preferring non-fallback
- Add 3 unit tests for fallback provider selection logic

## Usage Example
```yaml
providers:
  - type: openai
    host: api.openai.com
    endpoint: api.openai.com
    api_key: sk-primary-key

  - type: openai
    host: api.openai.com
    endpoint: backup.openai.com
    api_key: sk-backup-key
    is_fallback: true  # Only used when primary is unhealthy
```

## Test plan
- [x] All existing unit tests pass (146 tests)
- [x] New fallback selection tests pass:
  - `test_fallback_provider_not_selected_when_non_fallback_available`
  - `test_fallback_provider_selected_when_only_fallbacks_available`
  - `test_fallback_provider_selected_when_non_fallback_unhealthy`
- [x] `cargo build --release` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)