### PR TITLE
feat: authenticate during provider selection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -184,50 +184,50 @@ jobs:
               endpoint: localhost
               port: 9002
               tls: false
-              api_key: dummy-key-1
+              api_key: sk-openproxy-1
               auth_keys:
-                - key-for-provider1
+                - sk-auth-provider1
             - type: openai
               host: auth-test.local:8443
               endpoint: localhost
               port: 9003
               tls: false
-              api_key: dummy-key-2
+              api_key: sk-openproxy-2
               auth_keys:
-                - key-for-provider2
+                - sk-auth-provider2
             - type: openai
               host: auth-test.local:8443
               endpoint: localhost
               port: 9004
               tls: false
-              api_key: dummy-key-fallback
+              api_key: sk-openproxy-fallback
               auth_keys:
-                - key-for-fallback
+                - sk-auth-fallback
               is_fallback: true
             - type: openai
               host: auth-test.local:8080
               endpoint: localhost
               port: 9002
               tls: false
-              api_key: dummy-key-1
+              api_key: sk-openproxy-1
               auth_keys:
-                - key-for-provider1
+                - sk-auth-provider1
             - type: openai
               host: auth-test.local:8080
               endpoint: localhost
               port: 9003
               tls: false
-              api_key: dummy-key-2
+              api_key: sk-openproxy-2
               auth_keys:
-                - key-for-provider2
+                - sk-auth-provider2
             - type: openai
               host: auth-test.local:8080
               endpoint: localhost
               port: 9004
               tls: false
-              api_key: dummy-key-fallback
+              api_key: sk-openproxy-fallback
               auth_keys:
-                - key-for-fallback
+                - sk-auth-fallback
               is_fallback: true
           YAML
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -184,50 +184,50 @@ jobs:
               endpoint: localhost
               port: 9002
               tls: false
-              api_key: sk-openproxy-1
+              api_key: sk-api-key-1
               auth_keys:
-                - sk-auth-provider1
+                - sk-auth-key-1
             - type: openai
               host: auth-test.local:8443
               endpoint: localhost
               port: 9003
               tls: false
-              api_key: sk-openproxy-2
+              api_key: sk-api-key-2
               auth_keys:
-                - sk-auth-provider2
+                - sk-auth-key-2
             - type: openai
               host: auth-test.local:8443
               endpoint: localhost
               port: 9004
               tls: false
-              api_key: sk-openproxy-fallback
+              api_key: sk-api-key-fallback
               auth_keys:
-                - sk-auth-fallback
+                - sk-auth-key-fallback
               is_fallback: true
             - type: openai
               host: auth-test.local:8080
               endpoint: localhost
               port: 9002
               tls: false
-              api_key: sk-openproxy-1
+              api_key: sk-api-key-1
               auth_keys:
-                - sk-auth-provider1
+                - sk-auth-key-1
             - type: openai
               host: auth-test.local:8080
               endpoint: localhost
               port: 9003
               tls: false
-              api_key: sk-openproxy-2
+              api_key: sk-api-key-2
               auth_keys:
-                - sk-auth-provider2
+                - sk-auth-key-2
             - type: openai
               host: auth-test.local:8080
               endpoint: localhost
               port: 9004
               tls: false
-              api_key: sk-openproxy-fallback
+              api_key: sk-api-key-fallback
               auth_keys:
-                - sk-auth-fallback
+                - sk-auth-key-fallback
               is_fallback: true
           YAML
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -472,3 +472,12 @@ jobs:
           cd e2e
           python test_hot_upgrade.py
           echo "Hot upgrade E2E tests passed!"
+
+      - name: Run Auth Selection E2E tests
+        env:
+          OPENPROXY_BINARY: ${{ github.workspace }}/target/release/openproxy
+        run: |
+          echo "Testing auth-during-provider-selection..."
+          cd e2e
+          python test_auth_selection.py
+          echo "Auth selection E2E tests passed!"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -178,6 +178,57 @@ jobs:
               host: anthropic.localhost:8080
               endpoint: ${ANTHROPIC_ENDPOINT}
               api_key: ${ANTHROPIC_API_KEY}
+            # Auth selection test providers (same host, different auth_keys)
+            - type: openai
+              host: auth-test.local:8443
+              endpoint: localhost
+              port: 9002
+              tls: false
+              api_key: dummy-key-1
+              auth_keys:
+                - key-for-provider1
+            - type: openai
+              host: auth-test.local:8443
+              endpoint: localhost
+              port: 9003
+              tls: false
+              api_key: dummy-key-2
+              auth_keys:
+                - key-for-provider2
+            - type: openai
+              host: auth-test.local:8443
+              endpoint: localhost
+              port: 9004
+              tls: false
+              api_key: dummy-key-fallback
+              auth_keys:
+                - key-for-fallback
+              is_fallback: true
+            - type: openai
+              host: auth-test.local:8080
+              endpoint: localhost
+              port: 9002
+              tls: false
+              api_key: dummy-key-1
+              auth_keys:
+                - key-for-provider1
+            - type: openai
+              host: auth-test.local:8080
+              endpoint: localhost
+              port: 9003
+              tls: false
+              api_key: dummy-key-2
+              auth_keys:
+                - key-for-provider2
+            - type: openai
+              host: auth-test.local:8080
+              endpoint: localhost
+              port: 9004
+              tls: false
+              api_key: dummy-key-fallback
+              auth_keys:
+                - key-for-fallback
+              is_fallback: true
           YAML
 
           cat config.yml
@@ -473,9 +524,41 @@ jobs:
           python test_hot_upgrade.py
           echo "Hot upgrade E2E tests passed!"
 
+      - name: Start echo servers for auth selection test
+        run: |
+          # Start echo servers that return their server_id
+          for port in 9002 9003 9004; do
+            server_id="provider$((port - 9001))"
+            if [ "$port" == "9004" ]; then server_id="fallback"; fi
+            python3 -c "
+          from http.server import HTTPServer, BaseHTTPRequestHandler
+          import json
+
+          class Handler(BaseHTTPRequestHandler):
+              protocol_version = 'HTTP/1.1'
+              def do_GET(self):
+                  body = json.dumps({'server_id': '$server_id', 'path': self.path}).encode()
+                  self.send_response(200)
+                  self.send_header('Content-Type', 'application/json')
+                  self.send_header('Content-Length', str(len(body)))
+                  self.end_headers()
+                  self.wfile.write(body)
+              def do_POST(self):
+                  self.do_GET()
+              def log_message(self, *args):
+                  pass
+
+          HTTPServer(('127.0.0.1', $port), Handler).serve_forever()
+          " &
+          done
+          sleep 2
+          echo "Echo servers started on ports 9002, 9003, 9004"
+
       - name: Run Auth Selection E2E tests
         env:
-          OPENPROXY_BINARY: ${{ github.workspace }}/target/release/openproxy
+          PROXY_HTTPS_PORT: 8443
+          PROXY_HTTP_PORT: 8080
+          SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
         run: |
           echo "Testing auth-during-provider-selection..."
           cd e2e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,7 +442,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "bytes",
  "clap",
@@ -447,7 +457,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "signal-hook",
- "socket2 0.5.10",
+ "socket2",
  "structured-logger",
  "subtle",
  "thiserror",
@@ -701,10 +711,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -719,16 +730,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -886,7 +887,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1230,6 +1231,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e404bcd8afdaf006e529269d3e85a743f9480c3cef60034d77860d02964f3ba"
+checksum = "d0095ecd462946aa3927d9297b63ef82fb9a5316d7a37d134eeb36e58228615a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.6.0"
+version = "2.7.0"
 edition = "2021"
 description = "A LLM Proxy"
 
@@ -29,4 +29,4 @@ httplib = { version = "1.3.1", package = "http" }
 httparse = "1.10.1"
 bytes = "1.10.1"
 subtle = "2.6"
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6.1", features = ["all"] }

--- a/e2e/test_auth_selection.py
+++ b/e2e/test_auth_selection.py
@@ -48,7 +48,7 @@ def test_auth_selects_correct_provider():
         f"https://localhost:{HTTPS_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer key-for-provider1",
+            "Authorization": "Bearer sk-auth-provider1",
         },
         ssl_context=ssl_context,
     )
@@ -62,7 +62,7 @@ def test_auth_selects_correct_provider():
         f"https://localhost:{HTTPS_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer key-for-provider2",
+            "Authorization": "Bearer sk-auth-provider2",
         },
         ssl_context=ssl_context,
     )
@@ -77,7 +77,7 @@ def test_auth_selects_correct_provider():
         f"https://localhost:{HTTPS_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer key-for-fallback",
+            "Authorization": "Bearer sk-auth-fallback",
         },
         ssl_context=ssl_context,
     )
@@ -104,7 +104,7 @@ def test_auth_selects_correct_provider():
         f"http://localhost:{HTTP_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer key-for-provider1",
+            "Authorization": "Bearer sk-auth-provider1",
         },
     )
     assert status == 200, f"Expected 200, got {status}"
@@ -117,7 +117,7 @@ def test_auth_selects_correct_provider():
         f"http://localhost:{HTTP_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer key-for-fallback",
+            "Authorization": "Bearer sk-auth-fallback",
         },
     )
     assert status == 200, f"Expected 200, got {status}"

--- a/e2e/test_auth_selection.py
+++ b/e2e/test_auth_selection.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+E2E tests for auth-during-provider-selection feature.
+
+This tests the scenario where multiple providers match the same host/path,
+but have different auth_keys. The proxy should authenticate against all
+matching providers and select one that passes authentication.
+"""
+
+import os
+import sys
+import json
+import subprocess
+import tempfile
+import time
+import signal
+import ssl
+import socket
+import urllib.request
+import urllib.error
+from pathlib import Path
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import threading
+
+
+# Test configuration
+PROXY_BINARY = os.environ.get("OPENPROXY_BINARY", "../target/release/openproxy")
+HTTPS_PORT = 18443
+HTTP_PORT = 18080
+UPSTREAM_PORT_1 = 19001
+UPSTREAM_PORT_2 = 19002
+UPSTREAM_PORT_FALLBACK = 19003
+
+
+class EchoHandler(BaseHTTPRequestHandler):
+    """Simple HTTP echo server that returns the server identifier."""
+    protocol_version = "HTTP/1.1"
+    server_id = "unknown"
+
+    def do_GET(self):
+        response = {
+            "server_id": self.server_id,
+            "path": self.path,
+            "method": "GET",
+        }
+        body = json.dumps(response).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        req_body = self.rfile.read(content_length)
+        response = {
+            "server_id": self.server_id,
+            "path": self.path,
+            "method": "POST",
+            "body_length": content_length,
+        }
+        body = json.dumps(response).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass  # Suppress logging
+
+
+def create_handler_class(server_id: str):
+    """Create a handler class with a specific server_id."""
+    class Handler(EchoHandler):
+        pass
+    Handler.server_id = server_id
+    return Handler
+
+
+def start_upstream_server(port: int, server_id: str) -> HTTPServer:
+    """Start an upstream echo server."""
+    handler = create_handler_class(server_id)
+    server = HTTPServer(("127.0.0.1", port), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def generate_cert(cert_file: str, key_file: str):
+    """Generate a self-signed certificate."""
+    subprocess.run([
+        "openssl", "req", "-x509", "-newkey", "rsa:2048",
+        "-keyout", key_file, "-out", cert_file,
+        "-days", "1", "-nodes",
+        "-subj", "/CN=localhost",
+        "-addext", "subjectAltName=DNS:localhost,DNS:auth-test.local,IP:127.0.0.1"
+    ], check=True, capture_output=True)
+
+
+def create_config(cert_file: str, key_file: str, config_file: str):
+    """Create proxy configuration with multiple providers for the same host."""
+    config = f"""
+cert_file: {cert_file}
+private_key_file: {key_file}
+https_port: {HTTPS_PORT}
+http_port: {HTTP_PORT}
+
+providers:
+  # Provider 1: only accepts key "key-for-provider1"
+  - type: openai
+    host: auth-test.local
+    endpoint: localhost
+    port: {UPSTREAM_PORT_1}
+    tls: false
+    api_key: dummy-key-1
+    auth_keys:
+      - key-for-provider1
+
+  # Provider 2: only accepts key "key-for-provider2"
+  - type: openai
+    host: auth-test.local
+    endpoint: localhost
+    port: {UPSTREAM_PORT_2}
+    tls: false
+    api_key: dummy-key-2
+    auth_keys:
+      - key-for-provider2
+
+  # Fallback provider: accepts key "key-for-fallback"
+  - type: openai
+    host: auth-test.local
+    endpoint: localhost
+    port: {UPSTREAM_PORT_FALLBACK}
+    tls: false
+    api_key: dummy-key-fallback
+    auth_keys:
+      - key-for-fallback
+    is_fallback: true
+"""
+    with open(config_file, "w") as f:
+        f.write(config)
+
+
+def wait_for_port(port: int, timeout: float = 10.0) -> bool:
+    """Wait for a port to become available."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.1)
+    return False
+
+
+def http_request(url: str, headers: dict, ssl_context=None) -> tuple:
+    """Make an HTTP request and return (status_code, response_body)."""
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, context=ssl_context, timeout=10) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        return e.code, None
+
+
+def test_auth_selects_correct_provider():
+    """Test that authentication during provider selection works correctly."""
+    print("\n=== Testing auth-during-provider-selection ===\n")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cert_file = os.path.join(tmpdir, "cert.pem")
+        key_file = os.path.join(tmpdir, "key.pem")
+        config_file = os.path.join(tmpdir, "config.yml")
+
+        # Generate certificate
+        print("Generating self-signed certificate...")
+        generate_cert(cert_file, key_file)
+
+        # Start upstream servers
+        print("Starting upstream servers...")
+        server1 = start_upstream_server(UPSTREAM_PORT_1, "provider1")
+        server2 = start_upstream_server(UPSTREAM_PORT_2, "provider2")
+        server_fallback = start_upstream_server(UPSTREAM_PORT_FALLBACK, "fallback")
+
+        # Create config
+        print("Creating proxy configuration...")
+        create_config(cert_file, key_file, config_file)
+
+        # Start proxy
+        print("Starting openproxy...")
+        proxy_proc = subprocess.Popen(
+            [PROXY_BINARY, "start", "-c", config_file],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            # Wait for proxy to start
+            if not wait_for_port(HTTPS_PORT):
+                stdout, stderr = proxy_proc.communicate(timeout=5)
+                print(f"Proxy stdout: {stdout.decode()}")
+                print(f"Proxy stderr: {stderr.decode()}")
+                raise RuntimeError("Proxy failed to start")
+
+            print("Proxy started successfully\n")
+
+            # Create SSL context that trusts our self-signed cert
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(cert_file)
+
+            # Test 1: Request with key valid for provider1
+            print("Test 1: Request with key valid for provider1...")
+            status, data = http_request(
+                f"https://localhost:{HTTPS_PORT}/v1/test",
+                headers={
+                    "Host": "auth-test.local",
+                    "Authorization": "Bearer key-for-provider1",
+                },
+                ssl_context=ssl_context,
+            )
+            assert status == 200, f"Expected 200, got {status}"
+            assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+            print(f"  -> Routed to: {data['server_id']} ✓")
+
+            # Test 2: Request with key valid for provider2
+            print("Test 2: Request with key valid for provider2...")
+            status, data = http_request(
+                f"https://localhost:{HTTPS_PORT}/v1/test",
+                headers={
+                    "Host": "auth-test.local",
+                    "Authorization": "Bearer key-for-provider2",
+                },
+                ssl_context=ssl_context,
+            )
+            assert status == 200, f"Expected 200, got {status}"
+            assert data["server_id"] == "provider2", f"Expected provider2, got {data['server_id']}"
+            print(f"  -> Routed to: {data['server_id']} ✓")
+
+            # Test 3: Request with key valid only for fallback
+            # Non-fallback providers should fail auth, then fallback should be selected
+            print("Test 3: Request with key valid only for fallback...")
+            status, data = http_request(
+                f"https://localhost:{HTTPS_PORT}/v1/test",
+                headers={
+                    "Host": "auth-test.local",
+                    "Authorization": "Bearer key-for-fallback",
+                },
+                ssl_context=ssl_context,
+            )
+            assert status == 200, f"Expected 200, got {status}"
+            assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
+            print(f"  -> Routed to: {data['server_id']} ✓")
+
+            # Test 4: Request with invalid key (should fail with 401)
+            print("Test 4: Request with invalid key (should return 401)...")
+            status, data = http_request(
+                f"https://localhost:{HTTPS_PORT}/v1/test",
+                headers={
+                    "Host": "auth-test.local",
+                    "Authorization": "Bearer invalid-key",
+                },
+                ssl_context=ssl_context,
+            )
+            assert status == 401, f"Expected 401, got {status}"
+            print(f"  -> Got 401 as expected ✓")
+
+            # Test 5: HTTP/1.1 tests
+            print("Test 5: HTTP/1.1 request with key for provider1...")
+            status, data = http_request(
+                f"http://localhost:{HTTP_PORT}/v1/test",
+                headers={
+                    "Host": "auth-test.local",
+                    "Authorization": "Bearer key-for-provider1",
+                },
+            )
+            assert status == 200, f"Expected 200, got {status}"
+            assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+            print(f"  -> Routed to: {data['server_id']} ✓")
+
+            # Test 6: HTTP/1.1 with fallback key
+            print("Test 6: HTTP/1.1 request with key for fallback...")
+            status, data = http_request(
+                f"http://localhost:{HTTP_PORT}/v1/test",
+                headers={
+                    "Host": "auth-test.local",
+                    "Authorization": "Bearer key-for-fallback",
+                },
+            )
+            assert status == 200, f"Expected 200, got {status}"
+            assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
+            print(f"  -> Routed to: {data['server_id']} ✓")
+
+            print("\n=== All tests passed! ===\n")
+
+        finally:
+            # Cleanup
+            proxy_proc.terminate()
+            try:
+                proxy_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proxy_proc.kill()
+
+            server1.shutdown()
+            server2.shutdown()
+            server_fallback.shutdown()
+
+
+if __name__ == "__main__":
+    test_auth_selects_correct_provider()

--- a/e2e/test_auth_selection.py
+++ b/e2e/test_auth_selection.py
@@ -48,7 +48,7 @@ def test_auth_selects_correct_provider():
         f"https://localhost:{HTTPS_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer sk-auth-provider1",
+            "Authorization": "Bearer sk-auth-key-1",
         },
         ssl_context=ssl_context,
     )
@@ -62,7 +62,7 @@ def test_auth_selects_correct_provider():
         f"https://localhost:{HTTPS_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer sk-auth-provider2",
+            "Authorization": "Bearer sk-auth-key-2",
         },
         ssl_context=ssl_context,
     )
@@ -77,7 +77,7 @@ def test_auth_selects_correct_provider():
         f"https://localhost:{HTTPS_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer sk-auth-fallback",
+            "Authorization": "Bearer sk-auth-key-fallback",
         },
         ssl_context=ssl_context,
     )
@@ -104,7 +104,7 @@ def test_auth_selects_correct_provider():
         f"http://localhost:{HTTP_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer sk-auth-provider1",
+            "Authorization": "Bearer sk-auth-key-1",
         },
     )
     assert status == 200, f"Expected 200, got {status}"
@@ -117,7 +117,7 @@ def test_auth_selects_correct_provider():
         f"http://localhost:{HTTP_PORT}/v1/test",
         headers={
             "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer sk-auth-fallback",
+            "Authorization": "Bearer sk-auth-key-fallback",
         },
     )
     assert status == 200, f"Expected 200, got {status}"

--- a/e2e/test_auth_selection.py
+++ b/e2e/test_auth_selection.py
@@ -10,10 +10,7 @@ This test uses the proxy already started by the e2e workflow.
 """
 
 import os
-import json
-import ssl
-import urllib.request
-import urllib.error
+import httpx
 
 
 # Configuration from environment
@@ -22,119 +19,111 @@ HTTP_PORT = int(os.environ.get("PROXY_HTTP_PORT", "8080"))
 SSL_CERT_FILE = os.environ.get("SSL_CERT_FILE", "")
 
 
-def http_request(url: str, headers: dict, ssl_context=None) -> tuple:
-    """Make an HTTP request and return (status_code, response_body)."""
-    req = urllib.request.Request(url, headers=headers)
-    try:
-        with urllib.request.urlopen(req, context=ssl_context, timeout=10) as resp:
-            return resp.status, json.loads(resp.read().decode())
-    except urllib.error.HTTPError as e:
-        return e.code, None
-
-
 def test_auth_selects_correct_provider():
     """Test that authentication during provider selection works correctly."""
     print("\n=== Testing auth-during-provider-selection ===\n")
 
-    # Create SSL context that trusts the self-signed cert
-    ssl_context = None
-    if SSL_CERT_FILE:
-        ssl_context = ssl.create_default_context()
-        ssl_context.load_verify_locations(SSL_CERT_FILE)
-
     # Test 1: HTTPS request with key valid for provider1
     print("Test 1: HTTPS request with key valid for provider1...")
-    status, data = http_request(
-        f"https://localhost:{HTTPS_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer sk-auth-key-1",
-        },
-        ssl_context=ssl_context,
-    )
-    assert status == 200, f"Expected 200, got {status}"
-    assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
-    print(f"  -> Routed to: {data['server_id']} ✓")
+    with httpx.Client(verify=SSL_CERT_FILE) as client:
+        resp = client.get(
+            f"https://localhost:{HTTPS_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTPS_PORT}",
+                "Authorization": "Bearer sk-auth-key-1",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
 
     # Test 2: HTTPS request with key valid for provider2
     print("Test 2: HTTPS request with key valid for provider2...")
-    status, data = http_request(
-        f"https://localhost:{HTTPS_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer sk-auth-key-2",
-        },
-        ssl_context=ssl_context,
-    )
-    assert status == 200, f"Expected 200, got {status}"
-    assert data["server_id"] == "provider2", f"Expected provider2, got {data['server_id']}"
-    print(f"  -> Routed to: {data['server_id']} ✓")
+    with httpx.Client(verify=SSL_CERT_FILE) as client:
+        resp = client.get(
+            f"https://localhost:{HTTPS_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTPS_PORT}",
+                "Authorization": "Bearer sk-auth-key-2",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "provider2", f"Expected provider2, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
 
     # Test 3: HTTPS request with key valid only for fallback
     # Non-fallback providers should fail auth, then fallback should be selected
     print("Test 3: HTTPS request with key valid only for fallback...")
-    status, data = http_request(
-        f"https://localhost:{HTTPS_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer sk-auth-key-fallback",
-        },
-        ssl_context=ssl_context,
-    )
-    assert status == 200, f"Expected 200, got {status}"
-    assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
-    print(f"  -> Routed to: {data['server_id']} ✓")
+    with httpx.Client(verify=SSL_CERT_FILE) as client:
+        resp = client.get(
+            f"https://localhost:{HTTPS_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTPS_PORT}",
+                "Authorization": "Bearer sk-auth-key-fallback",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
 
     # Test 4: HTTPS request with invalid key (should fail with 401)
     print("Test 4: HTTPS request with invalid key (should return 401)...")
-    status, data = http_request(
-        f"https://localhost:{HTTPS_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTPS_PORT}",
-            "Authorization": "Bearer invalid-key",
-        },
-        ssl_context=ssl_context,
-    )
-    assert status == 401, f"Expected 401, got {status}"
-    print(f"  -> Got 401 as expected ✓")
+    with httpx.Client(verify=SSL_CERT_FILE) as client:
+        resp = client.get(
+            f"https://localhost:{HTTPS_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTPS_PORT}",
+                "Authorization": "Bearer invalid-key",
+            },
+        )
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+        print(f"  -> Got 401 as expected ✓")
 
     # Test 5: HTTP/1.1 request with key for provider1
     print("Test 5: HTTP request with key for provider1...")
-    status, data = http_request(
-        f"http://localhost:{HTTP_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer sk-auth-key-1",
-        },
-    )
-    assert status == 200, f"Expected 200, got {status}"
-    assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
-    print(f"  -> Routed to: {data['server_id']} ✓")
+    with httpx.Client() as client:
+        resp = client.get(
+            f"http://localhost:{HTTP_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTP_PORT}",
+                "Authorization": "Bearer sk-auth-key-1",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
 
     # Test 6: HTTP/1.1 request with fallback key
     print("Test 6: HTTP request with key for fallback...")
-    status, data = http_request(
-        f"http://localhost:{HTTP_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer sk-auth-key-fallback",
-        },
-    )
-    assert status == 200, f"Expected 200, got {status}"
-    assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
-    print(f"  -> Routed to: {data['server_id']} ✓")
+    with httpx.Client() as client:
+        resp = client.get(
+            f"http://localhost:{HTTP_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTP_PORT}",
+                "Authorization": "Bearer sk-auth-key-fallback",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
 
     # Test 7: HTTP/1.1 request with invalid key (should fail with 401)
     print("Test 7: HTTP request with invalid key (should return 401)...")
-    status, data = http_request(
-        f"http://localhost:{HTTP_PORT}/v1/test",
-        headers={
-            "Host": f"auth-test.local:{HTTP_PORT}",
-            "Authorization": "Bearer invalid-key",
-        },
-    )
-    assert status == 401, f"Expected 401, got {status}"
-    print(f"  -> Got 401 as expected ✓")
+    with httpx.Client() as client:
+        resp = client.get(
+            f"http://localhost:{HTTP_PORT}/v1/test",
+            headers={
+                "Host": f"auth-test.local:{HTTP_PORT}",
+                "Authorization": "Bearer invalid-key",
+            },
+        )
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+        print(f"  -> Got 401 as expected ✓")
 
     print("\n=== All tests passed! ===\n")
 

--- a/e2e/test_auth_selection.py
+++ b/e2e/test_auth_selection.py
@@ -5,153 +5,21 @@ E2E tests for auth-during-provider-selection feature.
 This tests the scenario where multiple providers match the same host/path,
 but have different auth_keys. The proxy should authenticate against all
 matching providers and select one that passes authentication.
+
+This test uses the proxy already started by the e2e workflow.
 """
 
 import os
-import sys
 import json
-import subprocess
-import tempfile
-import time
-import signal
 import ssl
-import socket
 import urllib.request
 import urllib.error
-from pathlib import Path
-from http.server import HTTPServer, BaseHTTPRequestHandler
-import threading
 
 
-# Test configuration
-PROXY_BINARY = os.environ.get("OPENPROXY_BINARY", "../target/release/openproxy")
-HTTPS_PORT = 18443
-HTTP_PORT = 18080
-UPSTREAM_PORT_1 = 19001
-UPSTREAM_PORT_2 = 19002
-UPSTREAM_PORT_FALLBACK = 19003
-
-
-class EchoHandler(BaseHTTPRequestHandler):
-    """Simple HTTP echo server that returns the server identifier."""
-    protocol_version = "HTTP/1.1"
-    server_id = "unknown"
-
-    def do_GET(self):
-        response = {
-            "server_id": self.server_id,
-            "path": self.path,
-            "method": "GET",
-        }
-        body = json.dumps(response).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def do_POST(self):
-        content_length = int(self.headers.get("Content-Length", 0))
-        req_body = self.rfile.read(content_length)
-        response = {
-            "server_id": self.server_id,
-            "path": self.path,
-            "method": "POST",
-            "body_length": content_length,
-        }
-        body = json.dumps(response).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format, *args):
-        pass  # Suppress logging
-
-
-def create_handler_class(server_id: str):
-    """Create a handler class with a specific server_id."""
-    class Handler(EchoHandler):
-        pass
-    Handler.server_id = server_id
-    return Handler
-
-
-def start_upstream_server(port: int, server_id: str) -> HTTPServer:
-    """Start an upstream echo server."""
-    handler = create_handler_class(server_id)
-    server = HTTPServer(("127.0.0.1", port), handler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    return server
-
-
-def generate_cert(cert_file: str, key_file: str):
-    """Generate a self-signed certificate."""
-    subprocess.run([
-        "openssl", "req", "-x509", "-newkey", "rsa:2048",
-        "-keyout", key_file, "-out", cert_file,
-        "-days", "1", "-nodes",
-        "-subj", "/CN=localhost",
-        "-addext", "subjectAltName=DNS:localhost,DNS:auth-test.local,IP:127.0.0.1"
-    ], check=True, capture_output=True)
-
-
-def create_config(cert_file: str, key_file: str, config_file: str):
-    """Create proxy configuration with multiple providers for the same host."""
-    config = f"""
-cert_file: {cert_file}
-private_key_file: {key_file}
-https_port: {HTTPS_PORT}
-http_port: {HTTP_PORT}
-
-providers:
-  # Provider 1: only accepts key "key-for-provider1"
-  - type: openai
-    host: auth-test.local
-    endpoint: localhost
-    port: {UPSTREAM_PORT_1}
-    tls: false
-    api_key: dummy-key-1
-    auth_keys:
-      - key-for-provider1
-
-  # Provider 2: only accepts key "key-for-provider2"
-  - type: openai
-    host: auth-test.local
-    endpoint: localhost
-    port: {UPSTREAM_PORT_2}
-    tls: false
-    api_key: dummy-key-2
-    auth_keys:
-      - key-for-provider2
-
-  # Fallback provider: accepts key "key-for-fallback"
-  - type: openai
-    host: auth-test.local
-    endpoint: localhost
-    port: {UPSTREAM_PORT_FALLBACK}
-    tls: false
-    api_key: dummy-key-fallback
-    auth_keys:
-      - key-for-fallback
-    is_fallback: true
-"""
-    with open(config_file, "w") as f:
-        f.write(config)
-
-
-def wait_for_port(port: int, timeout: float = 10.0) -> bool:
-    """Wait for a port to become available."""
-    start = time.time()
-    while time.time() - start < timeout:
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=1):
-                return True
-        except (socket.error, ConnectionRefusedError):
-            time.sleep(0.1)
-    return False
+# Configuration from environment
+HTTPS_PORT = int(os.environ.get("PROXY_HTTPS_PORT", "8443"))
+HTTP_PORT = int(os.environ.get("PROXY_HTTP_PORT", "8080"))
+SSL_CERT_FILE = os.environ.get("SSL_CERT_FILE", "")
 
 
 def http_request(url: str, headers: dict, ssl_context=None) -> tuple:
@@ -168,142 +36,107 @@ def test_auth_selects_correct_provider():
     """Test that authentication during provider selection works correctly."""
     print("\n=== Testing auth-during-provider-selection ===\n")
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cert_file = os.path.join(tmpdir, "cert.pem")
-        key_file = os.path.join(tmpdir, "key.pem")
-        config_file = os.path.join(tmpdir, "config.yml")
+    # Create SSL context that trusts the self-signed cert
+    ssl_context = None
+    if SSL_CERT_FILE:
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_verify_locations(SSL_CERT_FILE)
 
-        # Generate certificate
-        print("Generating self-signed certificate...")
-        generate_cert(cert_file, key_file)
+    # Test 1: HTTPS request with key valid for provider1
+    print("Test 1: HTTPS request with key valid for provider1...")
+    status, data = http_request(
+        f"https://localhost:{HTTPS_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTPS_PORT}",
+            "Authorization": "Bearer key-for-provider1",
+        },
+        ssl_context=ssl_context,
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+    print(f"  -> Routed to: {data['server_id']} ✓")
 
-        # Start upstream servers
-        print("Starting upstream servers...")
-        server1 = start_upstream_server(UPSTREAM_PORT_1, "provider1")
-        server2 = start_upstream_server(UPSTREAM_PORT_2, "provider2")
-        server_fallback = start_upstream_server(UPSTREAM_PORT_FALLBACK, "fallback")
+    # Test 2: HTTPS request with key valid for provider2
+    print("Test 2: HTTPS request with key valid for provider2...")
+    status, data = http_request(
+        f"https://localhost:{HTTPS_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTPS_PORT}",
+            "Authorization": "Bearer key-for-provider2",
+        },
+        ssl_context=ssl_context,
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert data["server_id"] == "provider2", f"Expected provider2, got {data['server_id']}"
+    print(f"  -> Routed to: {data['server_id']} ✓")
 
-        # Create config
-        print("Creating proxy configuration...")
-        create_config(cert_file, key_file, config_file)
+    # Test 3: HTTPS request with key valid only for fallback
+    # Non-fallback providers should fail auth, then fallback should be selected
+    print("Test 3: HTTPS request with key valid only for fallback...")
+    status, data = http_request(
+        f"https://localhost:{HTTPS_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTPS_PORT}",
+            "Authorization": "Bearer key-for-fallback",
+        },
+        ssl_context=ssl_context,
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
+    print(f"  -> Routed to: {data['server_id']} ✓")
 
-        # Start proxy
-        print("Starting openproxy...")
-        proxy_proc = subprocess.Popen(
-            [PROXY_BINARY, "start", "-c", config_file],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+    # Test 4: HTTPS request with invalid key (should fail with 401)
+    print("Test 4: HTTPS request with invalid key (should return 401)...")
+    status, data = http_request(
+        f"https://localhost:{HTTPS_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTPS_PORT}",
+            "Authorization": "Bearer invalid-key",
+        },
+        ssl_context=ssl_context,
+    )
+    assert status == 401, f"Expected 401, got {status}"
+    print(f"  -> Got 401 as expected ✓")
 
-        try:
-            # Wait for proxy to start
-            if not wait_for_port(HTTPS_PORT):
-                stdout, stderr = proxy_proc.communicate(timeout=5)
-                print(f"Proxy stdout: {stdout.decode()}")
-                print(f"Proxy stderr: {stderr.decode()}")
-                raise RuntimeError("Proxy failed to start")
+    # Test 5: HTTP/1.1 request with key for provider1
+    print("Test 5: HTTP request with key for provider1...")
+    status, data = http_request(
+        f"http://localhost:{HTTP_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTP_PORT}",
+            "Authorization": "Bearer key-for-provider1",
+        },
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+    print(f"  -> Routed to: {data['server_id']} ✓")
 
-            print("Proxy started successfully\n")
+    # Test 6: HTTP/1.1 request with fallback key
+    print("Test 6: HTTP request with key for fallback...")
+    status, data = http_request(
+        f"http://localhost:{HTTP_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTP_PORT}",
+            "Authorization": "Bearer key-for-fallback",
+        },
+    )
+    assert status == 200, f"Expected 200, got {status}"
+    assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
+    print(f"  -> Routed to: {data['server_id']} ✓")
 
-            # Create SSL context that trusts our self-signed cert
-            ssl_context = ssl.create_default_context()
-            ssl_context.load_verify_locations(cert_file)
+    # Test 7: HTTP/1.1 request with invalid key (should fail with 401)
+    print("Test 7: HTTP request with invalid key (should return 401)...")
+    status, data = http_request(
+        f"http://localhost:{HTTP_PORT}/v1/test",
+        headers={
+            "Host": f"auth-test.local:{HTTP_PORT}",
+            "Authorization": "Bearer invalid-key",
+        },
+    )
+    assert status == 401, f"Expected 401, got {status}"
+    print(f"  -> Got 401 as expected ✓")
 
-            # Test 1: Request with key valid for provider1
-            print("Test 1: Request with key valid for provider1...")
-            status, data = http_request(
-                f"https://localhost:{HTTPS_PORT}/v1/test",
-                headers={
-                    "Host": "auth-test.local",
-                    "Authorization": "Bearer key-for-provider1",
-                },
-                ssl_context=ssl_context,
-            )
-            assert status == 200, f"Expected 200, got {status}"
-            assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
-            print(f"  -> Routed to: {data['server_id']} ✓")
-
-            # Test 2: Request with key valid for provider2
-            print("Test 2: Request with key valid for provider2...")
-            status, data = http_request(
-                f"https://localhost:{HTTPS_PORT}/v1/test",
-                headers={
-                    "Host": "auth-test.local",
-                    "Authorization": "Bearer key-for-provider2",
-                },
-                ssl_context=ssl_context,
-            )
-            assert status == 200, f"Expected 200, got {status}"
-            assert data["server_id"] == "provider2", f"Expected provider2, got {data['server_id']}"
-            print(f"  -> Routed to: {data['server_id']} ✓")
-
-            # Test 3: Request with key valid only for fallback
-            # Non-fallback providers should fail auth, then fallback should be selected
-            print("Test 3: Request with key valid only for fallback...")
-            status, data = http_request(
-                f"https://localhost:{HTTPS_PORT}/v1/test",
-                headers={
-                    "Host": "auth-test.local",
-                    "Authorization": "Bearer key-for-fallback",
-                },
-                ssl_context=ssl_context,
-            )
-            assert status == 200, f"Expected 200, got {status}"
-            assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
-            print(f"  -> Routed to: {data['server_id']} ✓")
-
-            # Test 4: Request with invalid key (should fail with 401)
-            print("Test 4: Request with invalid key (should return 401)...")
-            status, data = http_request(
-                f"https://localhost:{HTTPS_PORT}/v1/test",
-                headers={
-                    "Host": "auth-test.local",
-                    "Authorization": "Bearer invalid-key",
-                },
-                ssl_context=ssl_context,
-            )
-            assert status == 401, f"Expected 401, got {status}"
-            print(f"  -> Got 401 as expected ✓")
-
-            # Test 5: HTTP/1.1 tests
-            print("Test 5: HTTP/1.1 request with key for provider1...")
-            status, data = http_request(
-                f"http://localhost:{HTTP_PORT}/v1/test",
-                headers={
-                    "Host": "auth-test.local",
-                    "Authorization": "Bearer key-for-provider1",
-                },
-            )
-            assert status == 200, f"Expected 200, got {status}"
-            assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
-            print(f"  -> Routed to: {data['server_id']} ✓")
-
-            # Test 6: HTTP/1.1 with fallback key
-            print("Test 6: HTTP/1.1 request with key for fallback...")
-            status, data = http_request(
-                f"http://localhost:{HTTP_PORT}/v1/test",
-                headers={
-                    "Host": "auth-test.local",
-                    "Authorization": "Bearer key-for-fallback",
-                },
-            )
-            assert status == 200, f"Expected 200, got {status}"
-            assert data["server_id"] == "fallback", f"Expected fallback, got {data['server_id']}"
-            print(f"  -> Routed to: {data['server_id']} ✓")
-
-            print("\n=== All tests passed! ===\n")
-
-        finally:
-            # Cleanup
-            proxy_proc.terminate()
-            try:
-                proxy_proc.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                proxy_proc.kill()
-
-            server1.shutdown()
-            server2.shutdown()
-            server_fallback.shutdown()
+    print("\n=== All tests passed! ===\n")
 
 
 if __name__ == "__main__":

--- a/e2e/test_h2_upstream.py
+++ b/e2e/test_h2_upstream.py
@@ -242,7 +242,7 @@ def test_h2_invalid_auth_key():
         print(f"  Response body: {resp.text}")
         assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
         assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
-        assert "missing authentication" in resp.text.lower(), f"Expected 'missing authentication' in body, got: {resp.text}"
+        assert "authentication failed" in resp.text.lower(), f"Expected 'authentication failed' in body, got: {resp.text}"
 
     print("\u2713 HTTP/2 invalid auth key test passed!")
 

--- a/e2e/test_https.py
+++ b/e2e/test_https.py
@@ -300,7 +300,7 @@ def test_invalid_auth_key_https_http2():
         print(f"  Response body: {resp.text}")
         assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
         assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
-        assert "missing authentication" in resp.text.lower(), f"Expected 'missing authentication' in body, got: {resp.text}"
+        assert "authentication failed" in resp.text.lower(), f"Expected 'authentication failed' in body, got: {resp.text}"
 
     print("\u2713 HTTPS HTTP/2 invalid auth key test passed!")
 


### PR DESCRIPTION
## Summary

- Add `select_provider_with_auth` method that performs authentication during provider selection
- Authentication is attempted on each matching provider (non-fallback first, then fallback) in weighted random order
- Returns the first provider that authenticates successfully
- Returns 401 only if ALL providers (including fallback) fail authentication
- Returns 404 if no providers match the host/path

## Motivation

Previously, provider selection and authentication were separate steps:
1. Select a provider based on host/path
2. Authenticate the request against the selected provider
3. Return 401 if authentication fails

This approach had a limitation: if multiple providers matched the same host/path, the one selected might not be the one the user's auth key was valid for. The user would get a 401 even if their key was valid for a different matching provider.

With this change, authentication is performed as part of provider selection:
1. Find all matching providers for the host/path
2. Try non-fallback providers first (in weighted random order)
3. For each provider, attempt authentication
4. Return the first provider that authenticates successfully
5. If all non-fallback providers fail, try fallback providers
6. Return 401 only if ALL providers fail authentication

## Use Cases

- **Multi-tenant setup**: Different users can have keys for different providers on the same host
- **Fallback authentication**: A fallback provider can be used when the primary fails authentication
- **Provider-specific keys**: Each provider can have its own set of valid auth keys

## Test plan

- [x] Added unit tests for `select_provider_with_auth` method
- [x] Test that provider with matching auth key is selected
- [x] Test that fallback providers are tried after non-fallback fail
- [x] Test that 401 is returned only when all providers fail
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)