### PR TITLE
refactor: add health_check config and deprecate CLI flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,6 @@ cargo fmt
 
 # Start the server
 ./target/release/openproxy start -c config.yml
-./target/release/openproxy start -c config.yml --enable-health-check
 ./target/release/openproxy start -c config.yml -p /var/run/openproxy.pid
 ```
 
@@ -105,6 +104,7 @@ YAML-based config with hot-reload via SIGHUP. Key fields:
 - `cert_file` / `private_key_file`: Required for HTTPS
 - `providers[]`: Type, host (for routing), endpoint (actual backend), api_key, weight, tls
 - `auth_keys`: Global authentication keys
+- `health_check.enabled` / `health_check.interval`: Enable health checks and set interval (default: 60s)
 
 ### Signal Handling
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.8.0"
+version = "2.9.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ auth_keys:
   - "client-api-key-1"
   - "client-api-key-2"
 
-# Health Check Interval (seconds)
-health_check_interval: 60
+# Health Check Configuration
+health_check:
+  enabled: true
+  interval: 60  # seconds
 
 # Provider Configuration
 providers:
@@ -162,9 +164,6 @@ providers:
 ```bash
 # Basic usage (HTTPS on configured port)
 ./openproxy start -c config.yml
-
-# With health checks enabled
-./openproxy start -c config.yml --enable-health-check
 
 # With PID file (useful for systemd integration)
 ./openproxy start -c config.yml -p /var/run/openproxy.pid
@@ -284,7 +283,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/openproxy start -c /etc/openproxy/config.yml -p /var/run/openproxy.pid --enable-health-check
+ExecStart=/usr/local/bin/openproxy start -c /etc/openproxy/config.yml -p /var/run/openproxy.pid
 ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=/var/run/openproxy.pid
 Restart=on-failure


### PR DESCRIPTION
## Summary

- Add `health_check` nested config with `enabled` and `interval` fields
- Deprecate `--enable-health-check` CLI flag (hidden from help, warns on use)
- Deprecate `health_check_interval` config field (still works for backwards compatibility)
- Add version to startup log for better debugging

## New Config Format

```yaml
health_check:
  enabled: true
  interval: 60  # optional, default 60 seconds
```

## Backwards Compatibility

| Config | Result |
|--------|--------|
| `health_check.enabled: true` | Enabled |
| `health_check.enabled: false` | Disabled |
| Only `health_check_interval: 60` | Enabled (backwards compat) |
| No config | Disabled |
| `--enable-health-check` CLI flag | Enabled (deprecated, warns) |

## Test plan

- [x] Run `cargo test` to verify all tests pass
- [x] Test with new `health_check.enabled: true` config
- [x] Test with deprecated `health_check_interval` config
- [x] Test with `--enable-health-check` CLI flag (should warn)
- [x] Verify startup log includes version

🤖 Generated with [Claude Code](https://claude.com/claude-code)