### PR TITLE
fix: remove non-existent 'main' branch from GitHub Actions triggers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, master]
+    branches: [master]
   pull_request:
-    branches: [main, master]
+    branches: [master]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,9 @@ name: Security Scan
 
 on:
   push:
-    branches: [main, master]
+    branches: [master]
   pull_request:
-    branches: [main, master]
+    branches: [master]
   schedule:
     # Run weekly on Monday at 00:00 UTC
     - cron: '0 0 * * 1'


### PR DESCRIPTION
## Summary
- 移除 `e2e.yml` 和 `security.yml` 中对不存在的 `main` 分支的引用
- 仓库默认分支是 `master`，`main` 分支并不存在

## Changes
- `.github/workflows/e2e.yml`: `branches: [main, master]` → `branches: [master]`
- `.github/workflows/security.yml`: `branches: [main, master]` → `branches: [master]`

## Test plan
- [x] 验证 GitHub Actions 在 push 和 PR 时正常触发

🤖 Generated with [Claude Code](https://claude.com/claude-code)