### PR TITLE
feat: add configurable http_max_header_size option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.9.0"
+version = "2.9.1"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -11,8 +11,6 @@ use crate::Error;
 
 use reader::{ChunkedReader, LimitedReader};
 
-const DEFAULT_BUFFER_SIZE: usize = 4096;
-
 const CRLF: &[u8] = b"\r\n";
 
 pub(crate) const QUERY_KEY_KEY: &str = "key";
@@ -45,9 +43,10 @@ pub struct Request<'a> {
 impl<'a> Request<'a> {
     pub async fn new<S: AsyncRead + Unpin + Send + Sync + 'a>(
         stream: S,
+        buffer_size: usize,
     ) -> Result<Request<'a>, Error> {
         Ok(Request {
-            payload: Payload::read_from(stream, DEFAULT_BUFFER_SIZE).await?,
+            payload: Payload::read_from(stream, buffer_size).await?,
         })
     }
 
@@ -104,9 +103,10 @@ pub struct Response<'a> {
 impl<'a> Response<'a> {
     pub async fn new<S: AsyncRead + Unpin + Send + Sync + 'a>(
         stream: S,
+        buffer_size: usize,
     ) -> Result<Response<'a>, Error> {
         Ok(Response {
-            payload: Payload::read_from(stream, DEFAULT_BUFFER_SIZE).await?,
+            payload: Payload::read_from(stream, buffer_size).await?,
         })
     }
 

--- a/src/http/reader/mod.rs
+++ b/src/http/reader/mod.rs
@@ -158,7 +158,7 @@ impl<R: AsyncRead + Unpin + Send + Sync> ChunkedReader<R> {
     pub fn new(reader: R) -> Self {
         Self {
             data_only: false,
-            reader: BufReader::new(reader, super::DEFAULT_BUFFER_SIZE),
+            reader: BufReader::new(reader, 4096),
             unread_chunk_length: 0,
             cleaning: false,
             finished: false,
@@ -790,7 +790,7 @@ mod tests {
 
     #[tokio::test]
     async fn chunked_reader_errors_when_header_too_long_without_crlf() {
-        let size = super::super::DEFAULT_BUFFER_SIZE;
+        let size = 4096;
         let data = vec![b'a'; size];
         let r = MemReader::new(data);
         let mut rdr = ChunkedReader::data_only(r);

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2167,7 +2167,7 @@ async fn health_check(
     }
     stream.write_all(b"\r\n").await?;
     stream.write_all(req).await?;
-    let response = http::Response::new(stream).await?;
+    let response = http::Response::new(stream, 4096).await?;
     let mut headers = [httparse::EMPTY_HEADER; 64];
     let mut parser = httparse::Response::new(&mut headers);
     parser.parse(response.payload.block())?;


### PR DESCRIPTION
## Summary
- Add `http_max_header_size` configuration option to control the maximum HTTP header size
- Default value: 4096 bytes, configurable range: 1KB - 1MB
- Fixes issues where large response headers would cause `HeaderTooLarge` errors

## Changes
- Add `http_max_header_size` config field with validation (min 1KB, max 1MB)
- Pass `buffer_size` as parameter to `Request::new()` and `Response::new()` instead of using hardcoded constant
- Update WebSocket handlers to use configurable header size
- Add 6 test cases for the new configuration option

## Example Configuration
```yaml
http_port: 8080
http_max_header_size: 8192  # 8KB
providers:
  - type: openai
    host: api.openai.com
    endpoint: api.openai.com
    api_key: sk-xxx
```

## Test plan
- [x] All 156 tests pass
- [x] Test default value (4096)
- [x] Test custom value
- [x] Test minimum boundary clamping (< 1KB → 1KB)
- [x] Test maximum boundary clamping (> 1MB → 1MB)
- [x] Test exact boundary values

🤖 Generated with [Claude Code](https://claude.com/claude-code)