### PR TITLE
fix: avoid NoProviderFound on h2->h1 fallback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -374,41 +374,8 @@ jobs:
           PROXY_AUTH_KEY: ${{ env.AUTH_KEY }}
           SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
         run: |
-          echo "Testing H2 client -> proxy -> H1 upstream fallback..."
-
-          # First verify the echo server is working directly
-          echo "Verifying echo server directly..."
-          curl -s http://127.0.0.1:9001/test | head -c 200
-          echo ""
-
-          # Client connects via HTTPS/H2, but upstream is plain HTTP
-          # Proxy should fallback to HTTP/1.1 for upstream connection
-          curl -s -D /tmp/fallback_headers.txt -o /tmp/fallback_response.json \
-            --cacert $SSL_CERT_FILE \
-            --http2 \
-            -H "Host: h1-fallback.localhost:8443" \
-            -H "Authorization: Bearer ${PROXY_AUTH_KEY}" \
-            "https://localhost:8443/test-fallback"
-
-          echo "Response headers:"
-          cat /tmp/fallback_headers.txt
-          echo "Response body:"
-          cat /tmp/fallback_response.json
-
-          # Verify response contains fallback success marker
-          if ! grep -q "fallback" /tmp/fallback_response.json; then
-            echo "::error::H2 fallback response does not contain success marker"
-            exit 1
-          fi
-
-          # Verify upstream protocol is HTTP/1.1 (fallback)
-          if ! grep -qi "x-upstream-protocol: http/1.1" /tmp/fallback_headers.txt; then
-            echo "::error::Expected x-upstream-protocol: http/1.1 header but not found"
-            cat /tmp/fallback_headers.txt
-            exit 1
-          fi
-
-          echo "H2 to H1 fallback test passed! (verified upstream protocol is HTTP/1.1)"
+          cd e2e
+          python test_h2_h1_fallback.py
 
       - name: Run Gemini E2E tests (HTTPS with curl)
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +399,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +472,7 @@ dependencies = [
  "socket2",
  "structured-logger",
  "subtle",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -578,6 +591,19 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -853,6 +879,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.9.4"
+version = "2.9.5"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ httparse = "1.10.1"
 bytes = "1.10.1"
 subtle = "2.6"
 socket2 = { version = "0.6.1", features = ["all"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.9.4"
+version = "2.9.5"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/e2e/test_h2_h1_fallback.py
+++ b/e2e/test_h2_h1_fallback.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""E2E test for: HTTP/2 client -> openproxy -> HTTP/1.1 upstream fallback.
+
+This specifically guards against a regression where the fallback path re-parses
+(or otherwise re-selects) the provider using the upstream Host header (endpoint),
+causing "No provider found" when provider.host != provider.endpoint.
+
+Expected setup (as in .github/workflows/e2e.yml):
+- openproxy is already running with a provider like:
+    host: h1-fallback.localhost:8443
+    endpoint: localhost
+    port: 9001
+    tls: false
+- an upstream HTTP/1.1 echo server is listening on 127.0.0.1:9001
+"""
+
+import os
+
+import httpx
+
+
+def _proxy_verify_param() -> str | bool:
+    # httpx verify param can be a CA bundle path or a boolean.
+    ca = os.environ.get("SSL_CERT_FILE")
+    return ca if ca else False
+
+
+def _make_h2_request(client: httpx.Client, method: str, url: str, authority: str, auth_key: str, **kwargs):
+    headers = kwargs.pop("headers", {})
+    headers = {
+        **headers,
+        "Authorization": f"Bearer {auth_key}",
+        # "Host" is not used for routing in HTTP/2, but keep it for debugging.
+        "Host": authority,
+    }
+
+    return client.request(
+        method,
+        url,
+        headers=headers,
+        # Force :authority for HTTP/2 routing.
+        extensions={"authority": authority},
+        **kwargs,
+    )
+
+
+def test_h2_client_to_h1_upstream_fallback():
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    https_port = int(os.environ.get("PROXY_HTTPS_PORT", "8443"))
+
+    # In the workflow we pass PROXY_AUTH_KEY. For compatibility with other scripts,
+    # allow OPENAI_API_KEY as fallback.
+    auth_key = os.environ.get("PROXY_AUTH_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not auth_key:
+        raise RuntimeError("Missing PROXY_AUTH_KEY (or OPENAI_API_KEY) env var")
+
+    authority = os.environ.get("FALLBACK_AUTHORITY", f"h1-fallback.localhost:{https_port}")
+
+    base_url = f"https://{proxy_host}:{https_port}"
+
+    with httpx.Client(http2=True, verify=_proxy_verify_param(), timeout=30.0) as client:
+        # GET
+        resp = _make_h2_request(client, "GET", f"{base_url}/test-fallback", authority, auth_key)
+        print("GET status:", resp.status_code)
+        print("GET HTTP version:", resp.http_version)
+        print("GET x-upstream-protocol:", resp.headers.get("x-upstream-protocol"))
+        print("GET body:", resp.text[:200] if len(resp.text) > 200 else resp.text)
+
+        assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}; body={resp.text!r}"
+        assert (
+            resp.headers.get("x-upstream-protocol", "").lower() == "http/1.1"
+        ), "Expected x-upstream-protocol: http/1.1"
+
+        data = resp.json()
+        assert data.get("fallback") == "success", f"Unexpected response: {data}"
+        assert data.get("path") == "/test-fallback", f"Unexpected path: {data}"
+
+        # POST
+        resp = _make_h2_request(
+            client,
+            "POST",
+            f"{base_url}/test-fallback-post",
+            authority,
+            auth_key,
+            json={"ping": "pong"},
+        )
+        print("POST status:", resp.status_code)
+        print("POST HTTP version:", resp.http_version)
+        print("POST x-upstream-protocol:", resp.headers.get("x-upstream-protocol"))
+        print("POST body:", resp.text[:200] if len(resp.text) > 200 else resp.text)
+
+        assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}; body={resp.text!r}"
+        assert (
+            resp.headers.get("x-upstream-protocol", "").lower() == "http/1.1"
+        ), "Expected x-upstream-protocol: http/1.1"
+
+        data = resp.json()
+        assert data.get("fallback") == "success", f"Unexpected response: {data}"
+        assert data.get("path") == "/test-fallback-post", f"Unexpected path: {data}"
+
+
+if __name__ == "__main__":
+    # Keep a single entry point for the workflow (python test_*.py).
+    test_h2_client_to_h1_upstream_fallback()
+    print("\n" + "=" * 50)
+    print("\u2713 H2 client -> H1 upstream fallback test passed!")
+    print("=" * 50)


### PR DESCRIPTION
## Summary
- Fix HTTP/2 -> HTTP/1.1 upstream fallback by avoiding provider re-selection based on the rewritten upstream Host header (endpoint).
- Skip serialized HTTP/1.1 response headers when streaming the upstream response body back to the HTTP/2 client.
- Harden `strip_port` for unbracketed IPv6 literals and add regression coverage (unit + e2e).

## Test plan
- [ ] GitHub Actions: E2E Tests workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)