### PR TITLE
feat: support YAML merge anchors in config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.9.6"
+version = "2.9.7"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.9.6"
+version = "2.9.7"
 edition = "2021"
 description = "A LLM Proxy"
 


### PR DESCRIPTION
## Summary
- Add support for YAML merge anchor syntax (`<<: *alias`) in configuration files
- Allow users to define common settings once and reuse them across multiple providers
- Add test case to verify merge anchor functionality

## Example Usage
```yaml
defaults: &defaults
  tls: true
  port: 443
  weight: 1.0

providers:
  - type: "openai"
    host: "openai.example.com"
    endpoint: "api.openai.com"
    api_key: "sk-key1"
    <<: *defaults
    
  - type: "anthropic"
    host: "anthropic.example.com"
    endpoint: "api.anthropic.com"
    api_key: "sk-key2"
    <<: *defaults
```

## Reference
- https://github.com/dtolnay/serde-yaml/issues/317

## Test plan
- [x] Run `cargo test test_yaml_merge_anchor` to verify the new test passes
- [x] Run `cargo test` to ensure no existing tests are broken
- [x] Run `cargo clippy` to check for lint issues