### PR TITLE
fix: use Cow<str> to support YAML merge anchors with quoted strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.9.7"
+version = "2.9.8"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.9.7"
+version = "2.9.8"
 edition = "2021"
 description = "A LLM Proxy"
 


### PR DESCRIPTION
## Summary

- Fix config loading error when using YAML merge anchors with dynamic auth keys
- Replace `&'a str` with `Cow<'a, str>` in config structs to support both borrowed and owned strings
- Add `visit_str` and `visit_string` methods to `APIKeys` Visitor

## Problem

When using YAML merge anchors (`<<: *alias`), `serde_yaml::to_string()` may change the quote style of strings. For example:

```yaml
# Original (double quotes)
api_key: "$(jq -r '.token' /path/to/creds.json)"

# After to_string() (single quotes)
api_key: '$(jq -r ''.token'' /path/to/creds.json)'
```

This caused deserialization to fail with:
```
Error: "expected a borrowed string"
```

Because the re-serialized string format couldn't be zero-copy borrowed by serde.

## Solution

Use `Cow<'a, str>` instead of `&'a str`, which can hold either a borrowed or owned string. When serde can borrow directly, it uses `Cow::Borrowed`; when it needs to allocate (due to quote style changes), it uses `Cow::Owned`.

## Test plan

- [x] Added test cases for YAML merge anchors with dynamic auth keys
- [x] All 160 existing tests pass
- [x] `cargo clippy` passes