### PR TITLE
feat: add HTTP CONNECT tunnel support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -551,3 +551,12 @@ jobs:
           cd e2e
           python test_auth_selection.py
           echo "Auth selection E2E tests passed!"
+
+      - name: Run Health Check Auth E2E tests
+        env:
+          OPENPROXY_BINARY: ${{ github.workspace }}/target/release/openproxy
+        run: |
+          echo "Testing health check auth error handling..."
+          cd e2e
+          python test_health_check_auth.py
+          echo "Health check auth E2E tests passed!"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -602,8 +602,8 @@ jobs:
             - ${AUTH_KEY}
 
           providers:
-            # For CONNECT tunnel, tls must be false so proxy does transparent TCP forwarding
-            # and client handles TLS directly with upstream
+            # CONNECT tunnel always uses transparent TCP (ignores tls setting).
+            # Client handles TLS directly with upstream after receiving "200 Connection Established".
             - type: openai
               host: ${OPENAI_ENDPOINT}
               endpoint: ${OPENAI_ENDPOINT}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -615,31 +615,19 @@ jobs:
           curl http://localhost:18080 || true
           echo "CONNECT-enabled proxy started on port 18080"
 
-      - name: Run CONNECT tunnel enabled tests
-        env:
-          PROXY_HOST: localhost
-          PROXY_PORT_CONNECT: 18080
-          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
-          TARGET_HOST: api.openai.com
-          TARGET_PORT: "443"
-          TEST_CONNECT_ENABLED: "true"
-        run: |
-          echo "Testing CONNECT tunnel when enabled..."
-          cd e2e
-          python test_connect_tunnel.py
-          echo "CONNECT tunnel enabled tests passed!"
-
-      - name: Run CONNECT tunnel data transfer and preread tests
+      - name: Run CONNECT tunnel tests (auth failure, no provider, data transfer, preread)
         env:
           PROXY_HOST: localhost
           PROXY_PORT_CONNECT: 18080
           OPENAI_API_KEY: ${{ env.AUTH_KEY }}
           ECHO_TARGET_HOST: local-service
           ECHO_TARGET_PORT: "19999"
+          TEST_CONNECT_AUTH_FAILURE: "true"
+          TEST_CONNECT_NO_PROVIDER: "true"
           TEST_CONNECT_DATA_TRANSFER: "true"
           TEST_CONNECT_PREREAD: "true"
         run: |
-          echo "Testing CONNECT tunnel data transfer and preread..."
+          echo "Testing CONNECT tunnel (auth failure, no provider, data transfer, preread)..."
           cd e2e
           python test_connect_tunnel.py
-          echo "CONNECT tunnel data transfer and preread tests passed!"
+          echo "CONNECT tunnel tests passed!"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -135,6 +135,11 @@ jobs:
               host: api.openai.com
               endpoint: ${OPENAI_ENDPOINT}
               api_key: ${OPENAI_API_KEY}
+            # Provider with OPENAI_ENDPOINT as host for CONNECT disabled test
+            - type: openai
+              host: ${OPENAI_ENDPOINT}
+              endpoint: ${OPENAI_ENDPOINT}
+              api_key: ${OPENAI_API_KEY}
             - type: openai
               host: echo.localhost:8443
               endpoint: localhost
@@ -566,6 +571,8 @@ jobs:
           PROXY_HOST: localhost
           PROXY_PORT: 8080
           OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          TARGET_HOST: ${{ secrets.OPENAI_HOST }}
+          TARGET_PORT: "443"
           TEST_CONNECT_DISABLED: "true"
         run: |
           echo "Testing CONNECT tunnel when disabled..."
@@ -609,6 +616,12 @@ jobs:
               endpoint: localhost
               port: 19999
               tls: false
+            # Unreachable provider for 502 test (port 19998 has no server)
+            - type: openai
+              host: unreachable-service
+              endpoint: localhost
+              port: 19998
+              tls: false
           YAML
 
           cat config_connect.yml
@@ -629,6 +642,7 @@ jobs:
           TEST_CONNECT_ENABLED: "true"
           TEST_CONNECT_AUTH_FAILURE: "true"
           TEST_CONNECT_NO_PROVIDER: "true"
+          TEST_CONNECT_PORT_MISMATCH: "true"
         run: |
           echo "Testing CONNECT tunnel when enabled..."
           cd e2e
@@ -649,3 +663,17 @@ jobs:
           cd e2e
           python test_connect_tunnel.py
           echo "CONNECT tunnel data transfer and preread tests passed!"
+
+      - name: Run CONNECT tunnel upstream unreachable test
+        env:
+          PROXY_HOST: localhost
+          PROXY_PORT_CONNECT: 18080
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          UNREACHABLE_TARGET_HOST: unreachable-service
+          UNREACHABLE_TARGET_PORT: "19998"
+          TEST_CONNECT_UPSTREAM_UNREACHABLE: "true"
+        run: |
+          echo "Testing CONNECT tunnel upstream unreachable..."
+          cd e2e
+          python test_connect_tunnel.py
+          echo "CONNECT tunnel upstream unreachable test passed!"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -560,3 +560,86 @@ jobs:
           cd e2e
           python test_health_check_auth.py
           echo "Health check auth E2E tests passed!"
+
+      - name: Run CONNECT tunnel disabled test
+        env:
+          PROXY_HOST: localhost
+          PROXY_PORT: 8080
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          TEST_CONNECT_DISABLED: "true"
+        run: |
+          echo "Testing CONNECT tunnel when disabled..."
+          cd e2e
+          python test_connect_tunnel.py
+          echo "CONNECT tunnel disabled test passed!"
+
+      - name: Create CONNECT-enabled config and start second proxy
+        env:
+          OPENAI_HOST: ${{ secrets.OPENAI_HOST }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          # Process OpenAI config
+          OPENAI_ENDPOINT="${OPENAI_HOST#https://}"
+          OPENAI_ENDPOINT="${OPENAI_ENDPOINT#http://}"
+          OPENAI_ENDPOINT="${OPENAI_ENDPOINT%/}"
+
+          # Create config with connect_tunnel_enabled
+          cat > config_connect.yml << YAML
+          cert_file: fullchain.pem
+          private_key_file: privkey.pem
+          https_port: 18443
+          http_port: 18080
+          connect_tunnel_enabled: true
+
+          auth_keys:
+            - ${AUTH_KEY}
+
+          providers:
+            - type: openai
+              host: api.openai.com
+              endpoint: ${OPENAI_ENDPOINT}
+              api_key: ${OPENAI_API_KEY}
+            # Echo server provider for data transfer test
+            - type: openai
+              host: local-service
+              endpoint: localhost
+              port: 19999
+              tls: false
+          YAML
+
+          cat config_connect.yml
+
+          # Start second openproxy instance with CONNECT enabled
+          ./target/release/openproxy start -c config_connect.yml &
+          sleep 3
+          curl http://localhost:18080 || true
+          echo "CONNECT-enabled proxy started on port 18080"
+
+      - name: Run CONNECT tunnel enabled tests
+        env:
+          PROXY_HOST: localhost
+          PROXY_PORT_CONNECT: 18080
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          TARGET_HOST: api.openai.com
+          TARGET_PORT: "443"
+          TEST_CONNECT_ENABLED: "true"
+        run: |
+          echo "Testing CONNECT tunnel when enabled..."
+          cd e2e
+          python test_connect_tunnel.py
+          echo "CONNECT tunnel enabled tests passed!"
+
+      - name: Run CONNECT tunnel data transfer and preread tests
+        env:
+          PROXY_HOST: localhost
+          PROXY_PORT_CONNECT: 18080
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          ECHO_TARGET_HOST: local-service
+          ECHO_TARGET_PORT: "19999"
+          TEST_CONNECT_DATA_TRANSFER: "true"
+          TEST_CONNECT_PREREAD: "true"
+        run: |
+          echo "Testing CONNECT tunnel data transfer and preread..."
+          cd e2e
+          python test_connect_tunnel.py
+          echo "CONNECT tunnel data transfer and preread tests passed!"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -596,7 +596,7 @@ jobs:
 
           providers:
             - type: openai
-              host: api.openai.com
+              host: ${OPENAI_ENDPOINT}
               endpoint: ${OPENAI_ENDPOINT}
               api_key: ${OPENAI_API_KEY}
             # Echo server provider for data transfer test
@@ -615,19 +615,33 @@ jobs:
           curl http://localhost:18080 || true
           echo "CONNECT-enabled proxy started on port 18080"
 
-      - name: Run CONNECT tunnel tests (auth failure, no provider, data transfer, preread)
+      - name: Run CONNECT tunnel enabled tests
+        env:
+          PROXY_HOST: localhost
+          PROXY_PORT_CONNECT: 18080
+          OPENAI_API_KEY: ${{ env.AUTH_KEY }}
+          TARGET_HOST: ${{ secrets.OPENAI_HOST }}
+          TARGET_PORT: "443"
+          TEST_CONNECT_ENABLED: "true"
+          TEST_CONNECT_AUTH_FAILURE: "true"
+          TEST_CONNECT_NO_PROVIDER: "true"
+        run: |
+          echo "Testing CONNECT tunnel when enabled..."
+          cd e2e
+          python test_connect_tunnel.py
+          echo "CONNECT tunnel enabled tests passed!"
+
+      - name: Run CONNECT tunnel data transfer and preread tests
         env:
           PROXY_HOST: localhost
           PROXY_PORT_CONNECT: 18080
           OPENAI_API_KEY: ${{ env.AUTH_KEY }}
           ECHO_TARGET_HOST: local-service
           ECHO_TARGET_PORT: "19999"
-          TEST_CONNECT_AUTH_FAILURE: "true"
-          TEST_CONNECT_NO_PROVIDER: "true"
           TEST_CONNECT_DATA_TRANSFER: "true"
           TEST_CONNECT_PREREAD: "true"
         run: |
-          echo "Testing CONNECT tunnel (auth failure, no provider, data transfer, preread)..."
+          echo "Testing CONNECT tunnel data transfer and preread..."
           cd e2e
           python test_connect_tunnel.py
-          echo "CONNECT tunnel tests passed!"
+          echo "CONNECT tunnel data transfer and preread tests passed!"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -595,10 +595,13 @@ jobs:
             - ${AUTH_KEY}
 
           providers:
+            # For CONNECT tunnel, tls must be false so proxy does transparent TCP forwarding
+            # and client handles TLS directly with upstream
             - type: openai
               host: ${OPENAI_ENDPOINT}
               endpoint: ${OPENAI_ENDPOINT}
               api_key: ${OPENAI_API_KEY}
+              tls: false
             # Echo server provider for data transfer test
             - type: openai
               host: local-service

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -600,6 +600,7 @@ jobs:
             - type: openai
               host: ${OPENAI_ENDPOINT}
               endpoint: ${OPENAI_ENDPOINT}
+              port: 443
               api_key: ${OPENAI_API_KEY}
               tls: false
             # Echo server provider for data transfer test

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,7 +5,8 @@
 useDefault = true
 
 [allowlist]
-description = "Ignore documentation examples"
+description = "Ignore documentation examples and test files with fake keys"
 paths = [
     '''README\.md''',
+    '''e2e/test_health_check_auth\.py''',
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.9.8"
+version = "2.10.0"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.9.8"
+version = "2.10.0"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/e2e/test_connect_tunnel.py
+++ b/e2e/test_connect_tunnel.py
@@ -1,0 +1,478 @@
+"""
+E2E tests for HTTP CONNECT tunnel support.
+
+These tests verify that:
+1. CONNECT requests are handled correctly when enabled
+2. CONNECT requests are rejected when disabled
+3. Authentication works for CONNECT requests
+4. The TCP tunnel correctly proxies data bidirectionally
+"""
+
+import os
+import socket
+import ssl
+import threading
+import time
+
+
+def test_connect_tunnel_disabled():
+    """Test that CONNECT requests return 403 when tunnel is disabled."""
+    print(f"\n{'='*50}")
+    print("Testing CONNECT tunnel when disabled")
+    print('='*50)
+
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    proxy_port = int(os.environ.get("PROXY_PORT", "8080"))
+    api_key = os.environ.get("OPENAI_API_KEY", "test-key")
+
+    # Create a raw socket connection to send CONNECT request
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+
+    try:
+        sock.connect((proxy_host, proxy_port))
+
+        # Send CONNECT request
+        request = (
+            f"CONNECT api.openai.com:443 HTTP/1.1\r\n"
+            f"Host: api.openai.com:443\r\n"
+            f"Authorization: Bearer {api_key}\r\n"
+            f"\r\n"
+        )
+        sock.sendall(request.encode())
+
+        # Read response
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+
+        response_str = response.decode('utf-8', errors='replace')
+        print(f"Response:\n{response_str}")
+
+        # Should get 403 Forbidden when CONNECT is disabled
+        assert "403" in response_str, f"Expected 403, got: {response_str}"
+        assert "CONNECT" in response_str.lower() or "tunnel" in response_str.lower() or "not enabled" in response_str.lower(), \
+            f"Expected message about CONNECT not enabled, got: {response_str}"
+
+        print("\u2713 CONNECT tunnel disabled test passed!")
+
+    finally:
+        sock.close()
+
+
+def test_connect_tunnel_enabled():
+    """Test that CONNECT requests work correctly when enabled."""
+    print(f"\n{'='*50}")
+    print("Testing CONNECT tunnel when enabled")
+    print('='*50)
+
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
+    api_key = os.environ.get("OPENAI_API_KEY", "test-key")
+    target_host = os.environ.get("TARGET_HOST", "api.openai.com")
+    target_port = int(os.environ.get("TARGET_PORT", "443"))
+
+    # Create a raw socket connection to send CONNECT request
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+
+    try:
+        sock.connect((proxy_host, proxy_port))
+
+        # Send CONNECT request
+        request = (
+            f"CONNECT {target_host}:{target_port} HTTP/1.1\r\n"
+            f"Host: {target_host}:{target_port}\r\n"
+            f"Authorization: Bearer {api_key}\r\n"
+            f"\r\n"
+        )
+        sock.sendall(request.encode())
+
+        # Read response
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+
+        response_str = response.decode('utf-8', errors='replace')
+        print(f"CONNECT Response:\n{response_str}")
+
+        # Should get 200 Connection Established
+        assert "200" in response_str, f"Expected 200, got: {response_str}"
+
+        # Now the socket is a tunnel - upgrade to TLS
+        context = ssl.create_default_context()
+        ssl_sock = context.wrap_socket(sock, server_hostname=target_host)
+
+        # Send a simple HTTP request through the tunnel
+        http_request = (
+            f"GET /v1/models HTTP/1.1\r\n"
+            f"Host: {target_host}\r\n"
+            f"Authorization: Bearer {api_key}\r\n"
+            f"Connection: close\r\n"
+            f"\r\n"
+        )
+        ssl_sock.sendall(http_request.encode())
+
+        # Read response (might be 200 or 401 depending on API key validity)
+        http_response = b""
+        while True:
+            chunk = ssl_sock.recv(4096)
+            if not chunk:
+                break
+            http_response += chunk
+
+        http_response_str = http_response.decode('utf-8', errors='replace')
+        print(f"HTTP Response through tunnel (first 500 chars):\n{http_response_str[:500]}")
+
+        # We should get a valid HTTP response (200 or 401)
+        assert "HTTP/1.1" in http_response_str, f"Expected HTTP response, got: {http_response_str[:200]}"
+
+        print("\u2713 CONNECT tunnel enabled test passed!")
+
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+
+def test_connect_tunnel_auth_failure():
+    """Test that CONNECT requests with invalid auth return 401."""
+    print(f"\n{'='*50}")
+    print("Testing CONNECT tunnel authentication failure")
+    print('='*50)
+
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+
+    try:
+        sock.connect((proxy_host, proxy_port))
+
+        # Send CONNECT request with invalid auth
+        request = (
+            f"CONNECT api.openai.com:443 HTTP/1.1\r\n"
+            f"Host: api.openai.com:443\r\n"
+            f"Authorization: Bearer invalid-key-12345\r\n"
+            f"\r\n"
+        )
+        sock.sendall(request.encode())
+
+        # Read response
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+
+        response_str = response.decode('utf-8', errors='replace')
+        print(f"Response:\n{response_str}")
+
+        # Should get 401 Unauthorized
+        assert "401" in response_str, f"Expected 401, got: {response_str}"
+        assert "authentication" in response_str.lower(), \
+            f"Expected authentication error message, got: {response_str}"
+
+        print("\u2713 CONNECT tunnel auth failure test passed!")
+
+    finally:
+        sock.close()
+
+
+def test_connect_tunnel_no_provider():
+    """Test that CONNECT requests for unknown hosts return 404."""
+    print(f"\n{'='*50}")
+    print("Testing CONNECT tunnel for unknown host")
+    print('='*50)
+
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
+    api_key = os.environ.get("OPENAI_API_KEY", "test-key")
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+
+    try:
+        sock.connect((proxy_host, proxy_port))
+
+        # Send CONNECT request for unknown host
+        request = (
+            f"CONNECT unknown-host.example.com:443 HTTP/1.1\r\n"
+            f"Host: unknown-host.example.com:443\r\n"
+            f"Authorization: Bearer {api_key}\r\n"
+            f"\r\n"
+        )
+        sock.sendall(request.encode())
+
+        # Read response
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+
+        response_str = response.decode('utf-8', errors='replace')
+        print(f"Response:\n{response_str}")
+
+        # Should get 404 Not Found
+        assert "404" in response_str, f"Expected 404, got: {response_str}"
+        assert "no provider" in response_str.lower(), \
+            f"Expected 'no provider found' message, got: {response_str}"
+
+        print("\u2713 CONNECT tunnel no provider test passed!")
+
+    finally:
+        sock.close()
+
+
+def start_echo_server(host, port, ready_event):
+    """Start a simple echo server for testing."""
+    server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_sock.bind((host, port))
+    server_sock.listen(1)
+    server_sock.settimeout(5)
+    ready_event.set()
+
+    try:
+        conn, addr = server_sock.accept()
+        conn.settimeout(5)
+        data = conn.recv(1024)
+        if data:
+            conn.sendall(data)  # Echo back
+        conn.close()
+    except socket.timeout:
+        pass
+    finally:
+        server_sock.close()
+
+
+def test_connect_tunnel_data_transfer():
+    """Test that data is correctly transferred through the CONNECT tunnel.
+
+    This test requires:
+    - A provider configured for the echo target host (e.g., 'local-service')
+    - The provider's port must match the echo server port
+    - Environment variables: ECHO_TARGET_HOST, ECHO_TARGET_PORT
+    """
+    print(f"\n{'='*50}")
+    print("Testing CONNECT tunnel data transfer")
+    print('='*50)
+
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
+    api_key = os.environ.get("OPENAI_API_KEY", "test-key")
+    target_host = os.environ.get("ECHO_TARGET_HOST", "local-service")
+    echo_port = int(os.environ.get("ECHO_TARGET_PORT", "19999"))
+
+    # Start echo server
+    echo_host = "127.0.0.1"
+    ready_event = threading.Event()
+
+    echo_thread = threading.Thread(
+        target=start_echo_server,
+        args=(echo_host, echo_port, ready_event)
+    )
+    echo_thread.daemon = True
+    echo_thread.start()
+
+    # Wait for server to be ready
+    ready_event.wait(timeout=5)
+    time.sleep(0.1)  # Give it a moment
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+
+    try:
+        sock.connect((proxy_host, proxy_port))
+
+        # Send CONNECT request
+        request = (
+            f"CONNECT {target_host}:{echo_port} HTTP/1.1\r\n"
+            f"Host: {target_host}:{echo_port}\r\n"
+            f"Authorization: Bearer {api_key}\r\n"
+            f"\r\n"
+        )
+        sock.sendall(request.encode())
+
+        # Read CONNECT response
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+
+        response_str = response.decode('utf-8', errors='replace')
+        print(f"CONNECT Response:\n{response_str}")
+
+        # Must get 200 Connection Established
+        assert "200" in response_str, f"Expected 200, got: {response_str}"
+
+        # Send test data through tunnel
+        test_data = b"Hello, CONNECT tunnel!"
+        sock.sendall(test_data)
+
+        # Receive echoed data
+        echoed = sock.recv(4096)
+        print(f"Sent: {test_data}")
+        print(f"Received: {echoed}")
+
+        assert echoed == test_data, f"Data mismatch: sent {test_data}, received {echoed}"
+        print("\u2713 CONNECT tunnel data transfer test passed!")
+
+    finally:
+        sock.close()
+        echo_thread.join(timeout=1)
+
+
+def test_connect_tunnel_preread():
+    """Test that pre-read data (sent immediately after CONNECT headers) is forwarded correctly.
+
+    This tests the critical fix for "optimistic CONNECT" where client sends data
+    (e.g., TLS ClientHello) immediately after the CONNECT request headers, possibly
+    in the same TCP segment. The proxy must forward this pre-read data to upstream
+    after sending "200 Connection Established".
+
+    This test requires:
+    - A provider configured for the echo target host
+    - The provider's port must match the echo server port
+    - Environment variables: ECHO_TARGET_HOST, ECHO_TARGET_PORT
+    """
+    print(f"\n{'='*50}")
+    print("Testing CONNECT tunnel pre-read data forwarding")
+    print('='*50)
+
+    proxy_host = os.environ.get("PROXY_HOST", "localhost")
+    proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
+    api_key = os.environ.get("OPENAI_API_KEY", "test-key")
+    target_host = os.environ.get("ECHO_TARGET_HOST", "local-service")
+    echo_port = int(os.environ.get("ECHO_TARGET_PORT", "19999"))
+
+    # Start echo server
+    echo_host = "127.0.0.1"
+    ready_event = threading.Event()
+
+    echo_thread = threading.Thread(
+        target=start_echo_server,
+        args=(echo_host, echo_port, ready_event)
+    )
+    echo_thread.daemon = True
+    echo_thread.start()
+
+    # Wait for server to be ready
+    ready_event.wait(timeout=5)
+    time.sleep(0.1)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+
+    try:
+        sock.connect((proxy_host, proxy_port))
+
+        # Send CONNECT request AND preread data in ONE sendall()
+        # This simulates "optimistic CONNECT" behavior where client sends
+        # data immediately after headers (e.g., TLS ClientHello)
+        preread_payload = b"PREREAD_TEST_DATA_12345"
+        request_with_preread = (
+            f"CONNECT {target_host}:{echo_port} HTTP/1.1\r\n"
+            f"Host: {target_host}:{echo_port}\r\n"
+            f"Authorization: Bearer {api_key}\r\n"
+            f"\r\n"
+        ).encode() + preread_payload
+
+        print(f"Sending CONNECT + {len(preread_payload)} bytes preread in single sendall()")
+        sock.sendall(request_with_preread)
+
+        # Read CONNECT response
+        response = b""
+        while b"\r\n\r\n" not in response:
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+
+        response_str = response.decode('utf-8', errors='replace')
+        print(f"CONNECT Response:\n{response_str}")
+
+        # Must get 200 Connection Established
+        assert "200" in response_str, f"Expected 200, got: {response_str}"
+
+        # The echoed preread data might arrive with the 200 response (same TCP segment)
+        # or in subsequent recv() calls. Collect until we have all expected bytes.
+        header_end_idx = response.find(b"\r\n\r\n") + 4
+        echoed = response[header_end_idx:]  # Start with any extra data after 200
+
+        # Keep receiving until we have all the preread payload bytes
+        while len(echoed) < len(preread_payload):
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            echoed += chunk
+
+        print(f"Preread sent: {preread_payload}")
+        print(f"Echoed back: {echoed}")
+
+        # The echo server should have received and echoed back the preread data
+        assert echoed == preread_payload, \
+            f"Preread data mismatch: sent {preread_payload}, received {echoed}"
+
+        print("\u2713 CONNECT tunnel preread test passed!")
+
+    finally:
+        sock.close()
+        echo_thread.join(timeout=1)
+
+
+if __name__ == "__main__":
+    import sys
+
+    tests_run = 0
+
+    # Run tests based on environment
+    # Test disabled case (default config without connect_tunnel_enabled)
+    if os.environ.get("TEST_CONNECT_DISABLED", "false").lower() == "true":
+        test_connect_tunnel_disabled()
+        tests_run += 1
+
+    # Test enabled case (config with connect_tunnel_enabled: true)
+    if os.environ.get("TEST_CONNECT_ENABLED", "false").lower() == "true":
+        test_connect_tunnel_enabled()
+        test_connect_tunnel_auth_failure()
+        test_connect_tunnel_no_provider()
+        tests_run += 3
+
+    # Test data transfer (requires local echo server provider)
+    if os.environ.get("TEST_CONNECT_DATA_TRANSFER", "false").lower() == "true":
+        test_connect_tunnel_data_transfer()
+        tests_run += 1
+
+    # Test preread forwarding (requires local echo server provider)
+    if os.environ.get("TEST_CONNECT_PREREAD", "false").lower() == "true":
+        test_connect_tunnel_preread()
+        tests_run += 1
+
+    if tests_run == 0:
+        print("\n" + "="*50)
+        print("ERROR: No tests were run!")
+        print("Set at least one of these environment variables to 'true':")
+        print("  TEST_CONNECT_DISABLED")
+        print("  TEST_CONNECT_ENABLED")
+        print("  TEST_CONNECT_DATA_TRANSFER")
+        print("  TEST_CONNECT_PREREAD")
+        print("="*50)
+        sys.exit(1)
+
+    print("\n" + "="*50)
+    print(f"\u2713 All {tests_run} CONNECT tunnel tests completed!")
+    print("="*50)

--- a/e2e/test_connect_tunnel.py
+++ b/e2e/test_connect_tunnel.py
@@ -445,12 +445,20 @@ if __name__ == "__main__":
         test_connect_tunnel_disabled()
         tests_run += 1
 
-    # Test enabled case (config with connect_tunnel_enabled: true)
+    # Test enabled case with TLS handshake (requires real API endpoint)
     if os.environ.get("TEST_CONNECT_ENABLED", "false").lower() == "true":
         test_connect_tunnel_enabled()
+        tests_run += 1
+
+    # Test authentication failure (returns 401)
+    if os.environ.get("TEST_CONNECT_AUTH_FAILURE", "false").lower() == "true":
         test_connect_tunnel_auth_failure()
+        tests_run += 1
+
+    # Test no provider found (returns 404)
+    if os.environ.get("TEST_CONNECT_NO_PROVIDER", "false").lower() == "true":
         test_connect_tunnel_no_provider()
-        tests_run += 3
+        tests_run += 1
 
     # Test data transfer (requires local echo server provider)
     if os.environ.get("TEST_CONNECT_DATA_TRANSFER", "false").lower() == "true":
@@ -468,6 +476,8 @@ if __name__ == "__main__":
         print("Set at least one of these environment variables to 'true':")
         print("  TEST_CONNECT_DISABLED")
         print("  TEST_CONNECT_ENABLED")
+        print("  TEST_CONNECT_AUTH_FAILURE")
+        print("  TEST_CONNECT_NO_PROVIDER")
         print("  TEST_CONNECT_DATA_TRANSFER")
         print("  TEST_CONNECT_PREREAD")
         print("="*50)

--- a/e2e/test_connect_tunnel.py
+++ b/e2e/test_connect_tunnel.py
@@ -63,6 +63,15 @@ def test_connect_tunnel_disabled():
         sock.close()
 
 
+def strip_url_scheme(host: str) -> str:
+    """Strip https:// or http:// prefix and trailing slash from host."""
+    if host.startswith("https://"):
+        host = host[8:]
+    elif host.startswith("http://"):
+        host = host[7:]
+    return host.rstrip("/")
+
+
 def test_connect_tunnel_enabled():
     """Test that CONNECT requests work correctly when enabled."""
     print(f"\n{'='*50}")
@@ -72,7 +81,7 @@ def test_connect_tunnel_enabled():
     proxy_host = os.environ.get("PROXY_HOST", "localhost")
     proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
     api_key = os.environ.get("OPENAI_API_KEY", "test-key")
-    target_host = os.environ.get("TARGET_HOST", "api.openai.com")
+    target_host = strip_url_scheme(os.environ.get("TARGET_HOST", "api.openai.com"))
     target_port = int(os.environ.get("TARGET_PORT", "443"))
 
     # Create a raw socket connection to send CONNECT request

--- a/e2e/test_connect_tunnel.py
+++ b/e2e/test_connect_tunnel.py
@@ -470,9 +470,11 @@ def test_connect_tunnel_port_mismatch():
     proxy_host = os.environ.get("PROXY_HOST", "localhost")
     proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
     api_key = os.environ.get("OPENAI_API_KEY", "test-key")
-    # Use TARGET_HOST but with a WRONG port (provider is configured for 443)
+    # Use TARGET_HOST but with a WRONG port
     target_host = strip_url_scheme(os.environ.get("TARGET_HOST", "api.openai.com"))
-    wrong_port = 8080  # Provider is configured for 443, not 8080
+    target_port = int(os.environ.get("TARGET_PORT", "443"))
+    # Pick a port that's definitely different from the configured one
+    wrong_port = 8080 if target_port != 8080 else 8081
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(10)
@@ -524,11 +526,10 @@ def test_connect_tunnel_upstream_unreachable():
     proxy_host = os.environ.get("PROXY_HOST", "localhost")
     proxy_port = int(os.environ.get("PROXY_PORT_CONNECT", "8081"))
     api_key = os.environ.get("OPENAI_API_KEY", "test-key")
-    # Use the echo server host but with a port where nothing is listening
-    # The provider for local-service is configured for port 19999
-    # We'll use port 19998 which should be closed
-    target_host = os.environ.get("UNREACHABLE_TARGET_HOST", "local-service")
-    unreachable_port = int(os.environ.get("UNREACHABLE_TARGET_PORT", "19999"))
+    # Use the unreachable-service host configured for a closed port
+    # Default port 19998 matches the CI provider config
+    target_host = os.environ.get("UNREACHABLE_TARGET_HOST", "unreachable-service")
+    unreachable_port = int(os.environ.get("UNREACHABLE_TARGET_PORT", "19998"))
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(10)

--- a/e2e/test_health_check_auth.py
+++ b/e2e/test_health_check_auth.py
@@ -1,0 +1,458 @@
+"""
+E2E tests for health check and authentication error handling.
+
+Tests the scenario where a provider is disabled due to health check failure,
+and verifies that requests with the disabled provider's API key return 404
+instead of 401.
+
+This test file is self-contained and manages its own openproxy instance and
+echo servers.
+"""
+
+import httpx
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+# Configuration
+PROXY_HTTPS_PORT = 18443
+PROXY_HTTP_PORT = 18080
+HEALTHY_ECHO_PORT = 19002
+UNHEALTHY_ECHO_PORT = 19003  # This port will NOT have a server running
+
+HEALTHY_API_KEY = "sk-healthy-key"
+UNHEALTHY_API_KEY = "sk-unhealthy-key"
+INVALID_API_KEY = "sk-invalid-key-12345"
+
+# Test host that both providers will match
+TEST_HOST = f"healthcheck-test.local:{PROXY_HTTPS_PORT}"
+TEST_HOST_HTTP = f"healthcheck-test.local:{PROXY_HTTP_PORT}"
+
+
+def create_config(cert_file: str, key_file: str) -> str:
+    """Generate a config file for the test."""
+    config = f"""
+cert_file: {cert_file}
+private_key_file: {key_file}
+https_port: {PROXY_HTTPS_PORT}
+http_port: {PROXY_HTTP_PORT}
+
+health_check:
+  enabled: true
+  interval: 2
+
+providers:
+  # Healthy provider - echo server will be running on this port
+  - type: openai
+    host: {TEST_HOST}
+    endpoint: localhost
+    port: {HEALTHY_ECHO_PORT}
+    tls: false
+    api_key: sk-upstream-healthy
+    auth_keys:
+      - {HEALTHY_API_KEY}
+
+  # Unhealthy provider - NO echo server will be running on this port
+  - type: openai
+    host: {TEST_HOST}
+    endpoint: localhost
+    port: {UNHEALTHY_ECHO_PORT}
+    tls: false
+    api_key: sk-upstream-unhealthy
+    auth_keys:
+      - {UNHEALTHY_API_KEY}
+
+  # HTTP providers (same setup)
+  - type: openai
+    host: {TEST_HOST_HTTP}
+    endpoint: localhost
+    port: {HEALTHY_ECHO_PORT}
+    tls: false
+    api_key: sk-upstream-healthy
+    auth_keys:
+      - {HEALTHY_API_KEY}
+
+  - type: openai
+    host: {TEST_HOST_HTTP}
+    endpoint: localhost
+    port: {UNHEALTHY_ECHO_PORT}
+    tls: false
+    api_key: sk-upstream-unhealthy
+    auth_keys:
+      - {UNHEALTHY_API_KEY}
+"""
+    return config
+
+
+def generate_self_signed_cert(tmpdir: str) -> tuple[str, str]:
+    """Generate a self-signed certificate for testing."""
+    cert_file = os.path.join(tmpdir, "cert.pem")
+    key_file = os.path.join(tmpdir, "key.pem")
+
+    subprocess.run([
+        "openssl", "req", "-x509", "-newkey", "rsa:2048",
+        "-keyout", key_file, "-out", cert_file,
+        "-days", "1", "-nodes",
+        "-subj", "/CN=localhost",
+        "-addext", "subjectAltName=DNS:localhost,IP:127.0.0.1"
+    ], check=True, capture_output=True)
+
+    return cert_file, key_file
+
+
+def start_echo_server(port: int, server_id: str) -> subprocess.Popen:
+    """Start an echo server that returns its server_id."""
+    server_code = f'''
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self):
+        body = json.dumps({{"server_id": "{server_id}", "path": self.path}}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        self.do_GET()
+
+    def log_message(self, *args):
+        pass
+
+HTTPServer(("127.0.0.1", {port}), Handler).serve_forever()
+'''
+    return subprocess.Popen([sys.executable, "-c", server_code])
+
+
+def find_openproxy_binary() -> str:
+    """Find the openproxy binary."""
+    # Try environment variable first
+    if "OPENPROXY_BINARY" in os.environ:
+        return os.environ["OPENPROXY_BINARY"]
+
+    # Try common locations
+    candidates = [
+        Path(__file__).parent.parent / "target" / "release" / "openproxy",
+        Path(__file__).parent.parent / "target" / "debug" / "openproxy",
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+
+    raise FileNotFoundError("Could not find openproxy binary")
+
+
+def start_openproxy(config_file: str, log_file: str) -> subprocess.Popen:
+    """Start the openproxy server with output redirected to a log file."""
+    binary = find_openproxy_binary()
+    log_handle = open(log_file, "w")
+    return subprocess.Popen(
+        [binary, "start", "-c", config_file],
+        stdout=log_handle,
+        stderr=log_handle,
+    ), log_handle
+
+
+def wait_for_server(port: int, timeout: float = 10.0, ssl: bool = False) -> bool:
+    """Wait for a server to be ready."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with httpx.Client(verify=False, timeout=1.0) as client:
+                scheme = "https" if ssl else "http"
+                client.get(f"{scheme}://localhost:{port}/")
+            return True
+        except Exception:
+            time.sleep(0.1)
+    return False
+
+
+def wait_for_health_check_failure(timeout: float = 15.0):
+    """Wait for health check to detect the unhealthy provider."""
+    # Health check interval is 2 seconds, so we wait a bit longer
+    print(f"  Waiting for health check to detect unhealthy provider...")
+    time.sleep(timeout)
+    print(f"  Health check wait complete")
+
+
+def test_health_check_auth_http1(cert_file: str):
+    """Test health check + auth error handling for HTTP/1.1."""
+    print(f"\n{'='*50}")
+    print("Testing HTTP/1.1 health check auth error handling")
+    print('='*50)
+
+    with httpx.Client(
+        base_url=f"https://localhost:{PROXY_HTTPS_PORT}",
+        http2=False,
+        verify=cert_file,
+        timeout=10.0,
+    ) as client:
+        # Test 1: Healthy provider's key should succeed (200)
+        print("  Test 1: Healthy provider key -> 200")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {HEALTHY_API_KEY}",
+                "Host": TEST_HOST,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        assert "server_id" in resp.text, f"Expected server_id in response: {resp.text}"
+        print("    PASSED")
+
+        # Test 2: Unhealthy provider's key should return 404 (provider disabled)
+        print("  Test 2: Unhealthy provider key -> 404")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {UNHEALTHY_API_KEY}",
+                "Host": TEST_HOST,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+        assert "no provider found" in resp.text.lower(), f"Expected 'no provider found' in body: {resp.text}"
+        print("    PASSED")
+
+        # Test 3: Invalid key should return 401 (auth failed)
+        print("  Test 3: Invalid key -> 401")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {INVALID_API_KEY}",
+                "Host": TEST_HOST,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+        assert "authentication failed" in resp.text.lower(), f"Expected 'authentication failed' in body: {resp.text}"
+        print("    PASSED")
+
+    print("\u2713 HTTP/1.1 health check auth tests passed!")
+
+
+def test_health_check_auth_http2(cert_file: str):
+    """Test health check + auth error handling for HTTP/2."""
+    print(f"\n{'='*50}")
+    print("Testing HTTP/2 health check auth error handling")
+    print('='*50)
+
+    with httpx.Client(
+        base_url=f"https://localhost:{PROXY_HTTPS_PORT}",
+        http2=True,
+        verify=cert_file,
+        timeout=10.0,
+    ) as client:
+        # Test 1: Healthy provider's key should succeed (200)
+        print("  Test 1: Healthy provider key -> 200")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {HEALTHY_API_KEY}",
+                "Host": TEST_HOST,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    HTTP Version: {resp.http_version}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        assert "server_id" in resp.text, f"Expected server_id in response: {resp.text}"
+        print("    PASSED")
+
+        # Test 2: Unhealthy provider's key should return 404 (provider disabled)
+        print("  Test 2: Unhealthy provider key -> 404")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {UNHEALTHY_API_KEY}",
+                "Host": TEST_HOST,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    HTTP Version: {resp.http_version}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+        assert "no provider found" in resp.text.lower(), f"Expected 'no provider found' in body: {resp.text}"
+        print("    PASSED")
+
+        # Test 3: Invalid key should return 401 (auth failed)
+        print("  Test 3: Invalid key -> 401")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {INVALID_API_KEY}",
+                "Host": TEST_HOST,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    HTTP Version: {resp.http_version}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+        assert "authentication failed" in resp.text.lower(), f"Expected 'authentication failed' in body: {resp.text}"
+        print("    PASSED")
+
+    print("\u2713 HTTP/2 health check auth tests passed!")
+
+
+def test_health_check_auth_plain_http():
+    """Test health check + auth error handling for plain HTTP."""
+    print(f"\n{'='*50}")
+    print("Testing plain HTTP health check auth error handling")
+    print('='*50)
+
+    with httpx.Client(
+        base_url=f"http://localhost:{PROXY_HTTP_PORT}",
+        timeout=10.0,
+    ) as client:
+        # Test 1: Healthy provider's key should succeed (200)
+        print("  Test 1: Healthy provider key -> 200")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {HEALTHY_API_KEY}",
+                "Host": TEST_HOST_HTTP,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        assert "server_id" in resp.text, f"Expected server_id in response: {resp.text}"
+        print("    PASSED")
+
+        # Test 2: Unhealthy provider's key should return 404 (provider disabled)
+        print("  Test 2: Unhealthy provider key -> 404")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {UNHEALTHY_API_KEY}",
+                "Host": TEST_HOST_HTTP,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+        assert "no provider found" in resp.text.lower(), f"Expected 'no provider found' in body: {resp.text}"
+        print("    PASSED")
+
+        # Test 3: Invalid key should return 401 (auth failed)
+        print("  Test 3: Invalid key -> 401")
+        resp = client.get(
+            "/v1/models",
+            headers={
+                "Authorization": f"Bearer {INVALID_API_KEY}",
+                "Host": TEST_HOST_HTTP,
+            },
+        )
+        print(f"    Status: {resp.status_code}")
+        print(f"    Body: {resp.text[:100] if resp.text else '(empty)'}")
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}"
+        assert "authentication failed" in resp.text.lower(), f"Expected 'authentication failed' in body: {resp.text}"
+        print("    PASSED")
+
+    print("\u2713 Plain HTTP health check auth tests passed!")
+
+
+def main():
+    """Main test runner."""
+    processes = []
+    file_handles = []
+    tmpdir = tempfile.mkdtemp()
+    proxy_log_file = os.path.join(tmpdir, "proxy.log")
+
+    try:
+        print("Setting up test environment...")
+
+        # Generate certificates
+        print("  Generating self-signed certificate...")
+        cert_file, key_file = generate_self_signed_cert(tmpdir)
+
+        # Create config
+        print("  Creating config file...")
+        config_content = create_config(cert_file, key_file)
+        config_file = os.path.join(tmpdir, "config.yml")
+        with open(config_file, "w") as f:
+            f.write(config_content)
+        print(f"  Config written to {config_file}")
+
+        # Start only the HEALTHY echo server (do NOT start the unhealthy one)
+        print(f"  Starting healthy echo server on port {HEALTHY_ECHO_PORT}...")
+        echo_proc = start_echo_server(HEALTHY_ECHO_PORT, "healthy")
+        processes.append(echo_proc)
+        time.sleep(1)
+
+        # Verify echo server is running
+        if not wait_for_server(HEALTHY_ECHO_PORT, timeout=5.0, ssl=False):
+            raise RuntimeError(f"Echo server on port {HEALTHY_ECHO_PORT} did not start")
+        print(f"  Echo server is ready")
+
+        # Start openproxy
+        print("  Starting openproxy...")
+        proxy_proc, log_handle = start_openproxy(config_file, proxy_log_file)
+        processes.append(proxy_proc)
+        file_handles.append(log_handle)
+
+        # Wait for proxy to be ready
+        if not wait_for_server(PROXY_HTTPS_PORT, timeout=10.0, ssl=True):
+            # Check if proxy crashed and print log file
+            if proxy_proc.poll() is not None:
+                log_handle.flush()
+                with open(proxy_log_file, "r") as f:
+                    print(f"  Proxy log:\n{f.read()}")
+            raise RuntimeError(f"Proxy on port {PROXY_HTTPS_PORT} did not start")
+        print(f"  Proxy is ready")
+
+        # Wait for health check to detect the unhealthy provider
+        wait_for_health_check_failure(timeout=8.0)
+
+        # Run tests
+        test_health_check_auth_http1(cert_file)
+        test_health_check_auth_http2(cert_file)
+        test_health_check_auth_plain_http()
+
+        print("\n" + "="*50)
+        print("\u2713 All health check auth tests passed!")
+        print("="*50)
+
+    finally:
+        # Cleanup
+        print("\nCleaning up...")
+        for proc in processes:
+            try:
+                proc.terminate()
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+
+        # Close file handles
+        for fh in file_handles:
+            try:
+                fh.close()
+            except Exception:
+                pass
+
+        # Clean up temp directory
+        import shutil
+        shutil.rmtree(tmpdir, ignore_errors=True)
+        print("Cleanup complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -90,9 +90,19 @@ impl<'a> Request<'a> {
         self.payload.is_websocket_upgrade
     }
 
+    pub fn method(&self) -> &str {
+        self.payload.method()
+    }
+
     /// Get the raw header bytes for forwarding (used for WebSocket upgrade)
     pub fn header_bytes(&self) -> &[u8] {
         &self.payload.internal_buffer[..self.payload.header_length + 2] // +2 for final CRLF
+    }
+
+    /// Get any bytes that were pre-read after the header (for CONNECT tunnel)
+    /// This returns data that was read during header parsing but belongs to the tunnel payload
+    pub fn take_preread_data(&self) -> &[u8] {
+        self.payload.preread_data()
     }
 }
 
@@ -145,7 +155,11 @@ pub(crate) struct WebSocketUpgrade {
 pub(crate) struct Payload<'a> {
     internal_buffer: Box<[u8]>,
     first_block_length: usize,
+    /// Original number of bytes read (before any adjustments for body processing)
+    /// Used to track pre-read data after headers for CONNECT tunnel
+    original_advanced: usize,
     header_length: usize,
+    method_range: Range<usize>,
     path_range: Range<usize>,
     host_range: Option<Range<usize>>,
     auth_range: Option<Range<usize>>,
@@ -309,6 +323,7 @@ impl<'a> Payload<'a> {
         let Ok(req_line_str) = std::str::from_utf8(req_line) else {
             return Err(Error::InvalidHeader);
         };
+        let method_range = get_req_method(req_line_str);
         let path_range = get_req_path(req_line_str);
         let path = &req_line_str[path_range.start..path_range.end];
         if let Some(host) = get_host(
@@ -404,6 +419,7 @@ impl<'a> Payload<'a> {
         if content_length.is_some() && transfer_encoding_chunked {
             return Err(Error::InvalidHeader);
         }
+        let original_advanced = advanced;
         let mut first_block_length = advanced;
         let header_length = header.len();
         let body = if let Some(real_content_length) = content_length {
@@ -461,7 +477,9 @@ impl<'a> Payload<'a> {
         Ok(Payload {
             internal_buffer: block,
             first_block_length,
+            original_advanced,
             header_length,
+            method_range,
             path_range,
             host_range,
             auth_range,
@@ -485,6 +503,29 @@ impl<'a> Payload<'a> {
                     &self.internal_buffer[self.path_range.start..self.path_range.end],
                 )
             }
+        }
+    }
+
+    fn method(&self) -> &str {
+        if self.method_range.start == self.method_range.end {
+            ""
+        } else {
+            unsafe {
+                std::str::from_utf8_unchecked(
+                    &self.internal_buffer[self.method_range.start..self.method_range.end],
+                )
+            }
+        }
+    }
+
+    /// Get any bytes that were pre-read after the header
+    /// This is useful for CONNECT tunnel where client may send data immediately after headers
+    fn preread_data(&self) -> &[u8] {
+        let header_end = self.header_length + CRLF.len();
+        if self.original_advanced > header_end {
+            &self.internal_buffer[header_end..self.original_advanced]
+        } else {
+            &[]
         }
     }
 
@@ -689,28 +730,55 @@ pub(crate) fn split_host_path(host: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// Strip port from host string (e.g., "localhost:8443" -> "localhost")
+/// Split host string into (host, port) parts.
+/// Handles IPv6 addresses correctly: "[::1]:8080" -> ("[::1]", Some(8080))
+/// Returns (host, None) if no port is present.
 #[inline]
-pub(crate) fn strip_port(host: &str) -> &str {
+pub(crate) fn split_host_port(host: &str) -> (&str, Option<u16>) {
     // Handle IPv6 addresses like [::1]:8080
     if let Some(bracket_idx) = host.rfind(']') {
         if let Some(colon_idx) = host[bracket_idx..].find(':') {
-            return &host[..bracket_idx + colon_idx];
+            let port_start = bracket_idx + colon_idx + 1;
+            let port = host[port_start..].parse().ok();
+            return (&host[..bracket_idx + colon_idx], port);
         }
-        return host;
+        return (host, None);
     }
 
     // If there are multiple ':' and no brackets, treat it as an IPv6 literal without a port.
     // (IPv6 with a port must be bracketed: "[::1]:8080")
     if host.bytes().filter(|&b| b == b':').count() != 1 {
-        return host;
+        return (host, None);
     }
 
     // Handle regular host:port
     if let Some(colon_idx) = host.rfind(':') {
-        return &host[..colon_idx];
+        let port = host[colon_idx + 1..].parse().ok();
+        return (&host[..colon_idx], port);
     }
-    host
+    (host, None)
+}
+
+/// Strip port from host string (e.g., "localhost:8443" -> "localhost")
+#[inline]
+pub(crate) fn strip_port(host: &str) -> &str {
+    split_host_port(host).0
+}
+
+/// Extract port from host string (e.g., "localhost:8443" -> Some(8443))
+/// Returns None if no port is present or if parsing fails.
+#[inline]
+pub(crate) fn extract_port(host: &str) -> Option<u16> {
+    split_host_port(host).1
+}
+
+/// Extract the HTTP method from the request line (e.g., "GET", "POST", "CONNECT")
+fn get_req_method(header: &str) -> Range<usize> {
+    if let Some(space_idx) = header.find(' ') {
+        0..space_idx
+    } else {
+        0..0
+    }
 }
 
 pub(crate) fn get_req_path(header: &str) -> Range<usize> {
@@ -803,6 +871,34 @@ mod tests {
     }
 
     #[test]
+    fn test_get_req_method() {
+        // Test GET request
+        let header = "GET /v1/completions HTTP/1.1";
+        let range = get_req_method(header);
+        assert_eq!(&header[range], "GET");
+
+        // Test POST request
+        let header = "POST /api/users HTTP/1.1";
+        let range = get_req_method(header);
+        assert_eq!(&header[range], "POST");
+
+        // Test CONNECT request
+        let header = "CONNECT api.openai.com:443 HTTP/1.1";
+        let range = get_req_method(header);
+        assert_eq!(&header[range], "CONNECT");
+
+        // Test empty header
+        let header = "";
+        let range = get_req_method(header);
+        assert_eq!(range, 0..0);
+
+        // Test header without space
+        let header = "INVALID";
+        let range = get_req_method(header);
+        assert_eq!(range, 0..0);
+    }
+
+    #[test]
     fn test_get_req_path() {
         // Test basic GET request
         let header = "GET /v1/completions HTTP/1.1";
@@ -851,6 +947,51 @@ mod tests {
     }
 
     #[test]
+    fn test_split_host_port() {
+        // Test with port
+        assert_eq!(split_host_port("localhost:8080"), ("localhost", Some(8080)));
+        assert_eq!(
+            split_host_port("api.openai.com:443"),
+            ("api.openai.com", Some(443))
+        );
+        assert_eq!(
+            split_host_port("example.com:8443"),
+            ("example.com", Some(8443))
+        );
+
+        // Test without port
+        assert_eq!(split_host_port("localhost"), ("localhost", None));
+        assert_eq!(split_host_port("api.openai.com"), ("api.openai.com", None));
+
+        // Test IPv6 addresses with port
+        assert_eq!(split_host_port("[::1]:8080"), ("[::1]", Some(8080)));
+        assert_eq!(
+            split_host_port("[2001:db8::1]:443"),
+            ("[2001:db8::1]", Some(443))
+        );
+        assert_eq!(
+            split_host_port("[fe80::1%eth0]:8080"),
+            ("[fe80::1%eth0]", Some(8080))
+        );
+
+        // Test IPv6 without port
+        assert_eq!(split_host_port("[::1]"), ("[::1]", None));
+        assert_eq!(split_host_port("[2001:db8::1]"), ("[2001:db8::1]", None));
+
+        // Test IPv6 without brackets (ambiguous, treated as no port)
+        assert_eq!(split_host_port("2001:db8::1"), ("2001:db8::1", None));
+        assert_eq!(split_host_port("fe80::1%eth0"), ("fe80::1%eth0", None));
+        assert_eq!(
+            split_host_port("2001:db8::1:443"),
+            ("2001:db8::1:443", None)
+        );
+
+        // Test invalid port
+        assert_eq!(split_host_port("localhost:invalid"), ("localhost", None));
+        assert_eq!(split_host_port("localhost:99999"), ("localhost", None));
+    }
+
+    #[test]
     fn test_strip_port() {
         // Test with port
         assert_eq!(strip_port("localhost:8080"), "localhost");
@@ -875,6 +1016,36 @@ mod tests {
         // Test IPv6 without port
         assert_eq!(strip_port("[::1]"), "[::1]");
         assert_eq!(strip_port("[2001:db8::1]"), "[2001:db8::1]");
+    }
+
+    #[test]
+    fn test_extract_port() {
+        // Test with port
+        assert_eq!(extract_port("localhost:8080"), Some(8080));
+        assert_eq!(extract_port("api.openai.com:443"), Some(443));
+        assert_eq!(extract_port("example.com:8443"), Some(8443));
+
+        // Test without port
+        assert_eq!(extract_port("localhost"), None);
+        assert_eq!(extract_port("api.openai.com"), None);
+
+        // Test IPv6 addresses with port
+        assert_eq!(extract_port("[::1]:8080"), Some(8080));
+        assert_eq!(extract_port("[2001:db8::1]:443"), Some(443));
+        assert_eq!(extract_port("[fe80::1%eth0]:8080"), Some(8080));
+
+        // Test IPv6 without port
+        assert_eq!(extract_port("[::1]"), None);
+        assert_eq!(extract_port("[2001:db8::1]"), None);
+
+        // Test IPv6 without brackets (should return None, ambiguous)
+        assert_eq!(extract_port("2001:db8::1"), None);
+        assert_eq!(extract_port("fe80::1%eth0"), None);
+        assert_eq!(extract_port("2001:db8::1:443"), None);
+
+        // Test invalid port
+        assert_eq!(extract_port("localhost:invalid"), None);
+        assert_eq!(extract_port("localhost:99999"), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ struct Program {
     enable_health_check: bool,
     health_check_interval: u64,
     graceful_shutdown_timeout: u64,
+    connect_tunnel_enabled: bool,
     shutdown_tx: tokio::sync::broadcast::Sender<()>,
     providers: Arc<Vec<Box<dyn Provider>>>,
 }
@@ -222,6 +223,7 @@ impl Program {
             enable_health_check,
             health_check_interval,
             graceful_shutdown_timeout: config.graceful_shutdown_timeout.unwrap_or(5),
+            connect_tunnel_enabled: config.connect_tunnel_enabled,
             shutdown_tx,
             providers: Arc::new(providers),
         })
@@ -401,6 +403,9 @@ struct Config<'a> {
     health_check_interval: Option<u64>,
     /// Graceful shutdown timeout in seconds (default: 5)
     graceful_shutdown_timeout: Option<u64>,
+    /// Enable CONNECT tunnel support (default: false)
+    #[serde(default)]
+    connect_tunnel_enabled: bool,
     /// Providers configuration
     #[serde(borrow)]
     providers: Vec<ProviderConfig<'a>>,
@@ -785,6 +790,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };
@@ -847,6 +853,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };
@@ -906,6 +913,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };
@@ -963,6 +971,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };
@@ -1050,6 +1059,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };
@@ -1105,6 +1115,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };
@@ -1146,6 +1157,7 @@ mod tests {
             enable_health_check: false,
             health_check_interval: 0,
             graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
             shutdown_tx: tokio::sync::broadcast::channel(1).0,
             providers: Arc::new(providers),
         };

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -135,6 +135,11 @@ pub trait Provider: Send + Sync {
         true
     }
 
+    /// Extract port from sock_address (e.g., "api.openai.com:443" -> 443)
+    fn port(&self) -> u16 {
+        http::extract_port(self.sock_address()).unwrap_or(443)
+    }
+
     fn is_healthy(&self) -> bool;
     fn set_healthy(&self, healthy: bool);
 


### PR DESCRIPTION
## Summary
- Add HTTP CONNECT method support for TCP tunneling through the proxy
- Allow clients to use openproxy as an HTTPS proxy (e.g., `curl -x http://proxy:8080 https://api.openai.com`)
- Reuse existing provider selection and authentication for security

## Changes
- Add `connect_tunnel_enabled` config option (default: `false`)
- Add `method()` to Request for detecting CONNECT requests
- Add `split_host_port()` for parsing host:port with IPv6 support
- Add `preread_data()` to forward bytes read after CONNECT headers (handles optimistic CONNECT)
- Validate CONNECT port matches provider's configured port
- Support TLS to upstream via `get_or_create_h1()` reuse
- Add comprehensive E2E tests

## Configuration Example
```yaml
connect_tunnel_enabled: true

providers:
  - type: openai
    host: api.openai.com
    endpoint: api.openai.com
    port: 443
    api_key: sk-xxx
```

## Test plan
- [x] Unit tests pass (163 tests)
- [x] Clippy passes (only pre-existing warnings)
- [ ] E2E tests with `TEST_CONNECT_DISABLED=true`
- [ ] E2E tests with `TEST_CONNECT_ENABLED=true`
- [ ] E2E tests with `TEST_CONNECT_DATA_TRANSFER=true`
- [ ] E2E tests with `TEST_CONNECT_PREREAD=true`