### PR TITLE
fix: avoid Program lock across HTTP/1.1 request read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.11.2"
+version = "2.11.3"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.11.2"
+version = "2.11.3"
 edition = "2021"
 description = "A LLM Proxy"
 


### PR DESCRIPTION
## Summary
- Fix a reload stall where HTTP/1.1 keep-alive connections could hold a Program read lock while waiting for the next request header.
- Ensure SIGHUP reload can always acquire the Program write lock by avoiding holding the lock across client network I/O.

## Test plan
- [x] cargo test
- [x] cargo clippy
- [ ] Deploy binary and verify `systemctl reload openproxy` does not stall new requests