### PR TITLE
feat: add optional TLS support for CONNECT tunnel upstream

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -779,14 +779,22 @@ jobs:
             - ${AUTH_KEY}
 
           providers:
-            # CONNECT tunnel always uses transparent TCP (ignores tls setting).
-            # Client handles TLS directly with upstream after receiving "200 Connection Established".
+            # CONNECT tunnel upstream transport is controlled by provider.tls:
+            # - tls: false -> plain TCP (standard CONNECT; client negotiates TLS inside the tunnel)
+            # - tls: true  -> OpenProxy establishes TLS to upstream; client must send plaintext inside the tunnel
             - type: openai
               host: ${OPENAI_ENDPOINT}
               endpoint: ${OPENAI_ENDPOINT}
               port: 443
               api_key: ${OPENAI_API_KEY}
               tls: false
+            # tls:true provider for CONNECT tunnel (used by TEST_CONNECT_UPSTREAM_TLS)
+            - type: openai
+              host: connect-tls
+              endpoint: ${OPENAI_ENDPOINT}
+              port: 443
+              api_key: ${OPENAI_API_KEY}
+              tls: true
             # Echo server provider for data transfer test
             - type: openai
               host: local-service
@@ -816,7 +824,10 @@ jobs:
           OPENAI_API_KEY: ${{ env.AUTH_KEY }}
           TARGET_HOST: ${{ secrets.OPENAI_HOST }}
           TARGET_PORT: "443"
+          TLS_CONNECT_HOST: "connect-tls"
+          TLS_CONNECT_PORT: "443"
           TEST_CONNECT_ENABLED: "true"
+          TEST_CONNECT_UPSTREAM_TLS: "true"
           TEST_CONNECT_AUTH_FAILURE: "true"
           TEST_CONNECT_NO_PROVIDER: "true"
           TEST_CONNECT_PORT_MISMATCH: "true"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.11.3"
+version = "2.11.4"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.11.3"
+version = "2.11.4"
 edition = "2021"
 description = "A LLM Proxy"
 


### PR DESCRIPTION
## Summary
- Allow CONNECT tunnel to optionally use TLS when connecting to upstream
- Controlled by the provider's `tls` config field
- Set `tls: false` for standard transparent TCP behavior
- Set `tls: true` for secure transport between proxy and upstream

## Test plan
- [x] Existing E2E tests pass (test_connect_tunnel.py uses `tls: false`)
- [x] GitHub Actions CI passes