### PR TITLE
feat: add arm64 architecture support for Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,6 +53,20 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
         run: git checkout "$TAG"
 
+      - name: Download release binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh release download "$TAG" \
+            --pattern "openproxy-linux-amd64.tar.gz" \
+            --pattern "openproxy-linux-arm64.tar.gz"
+          tar -xzf openproxy-linux-amd64.tar.gz
+          tar -xzf openproxy-linux-arm64.tar.gz
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -86,6 +100,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,13 @@ jobs:
           cp target/x86_64-unknown-linux-musl/release/openproxy dist/openproxy-linux-amd64
           cd dist && tar -czvf openproxy-linux-amd64.tar.gz openproxy-linux-amd64
 
+      - name: Build Linux arm64 binary (static linking with musl)
+        if: steps.check_version.outputs.should_release == 'true'
+        run: |
+          cross build --release --target aarch64-unknown-linux-musl
+          cp target/aarch64-unknown-linux-musl/release/openproxy dist/openproxy-linux-arm64
+          cd dist && tar -czvf openproxy-linux-arm64.tar.gz openproxy-linux-arm64
+
       - name: Setup Node.js
         if: steps.check_version.outputs.should_release == 'true'
         uses: actions/setup-node@v4
@@ -99,6 +106,7 @@ jobs:
           generate_release_notes: false
           files: |
             dist/openproxy-linux-amd64.tar.gz
+            dist/openproxy-linux-arm64.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.11.5"
+version = "2.11.6"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.11.5"
+version = "2.11.6"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,8 @@
-# Build stage
-FROM rust:1.85-slim AS builder
-
-WORKDIR /usr/src/app
-
-# Copy Cargo files
-COPY Cargo.toml ./
-
-# Copy source code
-COPY src ./src
-
-# Build the application
-RUN cargo build --release --bin openproxy
-
-# Runtime stage
 FROM ubuntu:22.04
 
-# Copy the binary from builder stage
-COPY --from=builder /usr/src/app/target/release/openproxy /usr/local/bin/openproxy
+ARG TARGETARCH
+
+COPY openproxy-linux-${TARGETARCH} /usr/local/bin/openproxy
 
 # Note: Port is determined by config file (https_port/http_port)
 # Map ports at runtime: docker run -p <host_port>:<container_port>


### PR DESCRIPTION
## Summary
- Add `aarch64-unknown-linux-musl` cross-compilation in release workflow to build arm64 static binary
- Update Docker publish workflow to download pre-built binaries and build multi-platform images (`linux/amd64`, `linux/arm64`)
- Replace multi-stage Dockerfile with a simpler version that copies pre-built binaries using `TARGETARCH`

## Test plan
- [ ] Verify release workflow builds both amd64 and arm64 binaries successfully
- [ ] Verify Docker publish workflow builds and pushes multi-arch manifest
- [ ] Verify `docker manifest inspect` shows both `amd64` and `arm64` platforms
- [ ] Pull and run image on arm64 host to confirm it works