### PR TITLE
feat: support dynamic OpenAI api_key and add e2e coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -614,6 +614,15 @@ jobs:
           python test_anthropic_oauth.py
           echo "Anthropic OAuth E2E tests passed!"
 
+      - name: Run OpenAI Dynamic API Key E2E tests
+        env:
+          OPENPROXY_BINARY: ${{ github.workspace }}/target/release/openproxy
+        run: |
+          echo "Testing OpenAI dynamic API key authentication..."
+          cd e2e
+          python test_openai_dynamic_api_key.py
+          echo "OpenAI dynamic API key E2E tests passed!"
+
       - name: Run Anthropic API E2E tests
         env:
           PROXY_HTTPS_URL: https://localhost:8443

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,4 +9,5 @@ description = "Ignore documentation examples and test files with fake keys"
 paths = [
     '''README\.md''',
     '''e2e/test_health_check_auth\.py''',
+    '''e2e/test_openai_dynamic_api_key\.py''',
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`openproxy` is a Rust 2021 project centered in `src/`:
+- `src/main.rs`: CLI entrypoint (`openproxy start -c ...`) and signal handling.
+- `src/lib.rs`: config loading, runtime wiring, provider selection, and shutdown flow.
+- `src/http/`, `src/h2client/`, `src/websocket/`: protocol handling.
+- `src/provider/`, `src/worker/`, `src/executor/`: routing, business logic, and async execution.
+
+End-to-end tests live in `e2e/` as `test_*.py` files, with helpers like `e2e/websocket_echo_server.py`. CI/CD workflows are in `.github/workflows/` (notably `e2e.yml`, `security.yml`, and release workflows).
+
+## Build, Test, and Development Commands
+- `cargo build --release`: build optimized binary (`target/release/openproxy`).
+- `cargo run -- start -c config.yml`: run locally without a separate build step.
+- `cargo test --lib --verbose`: run Rust unit/integration tests (CI baseline).
+- `cargo test`: run all Rust tests.
+- `cargo fmt --all` and `cargo clippy --all-targets --all-features`: formatting and lint checks before opening a PR.
+
+For E2E tests (Python 3.11 in CI):
+- `pip install openai pydantic "httpx[http2]" "websockets==10.4" websocket-client pyyaml anthropic`
+- `cd e2e && python test_https.py` (swap in other `test_*.py` as needed)
+
+## Coding Style & Naming Conventions
+Follow standard Rust style (4-space indentation, `rustfmt` defaults). Use:
+- `snake_case` for files, modules, functions, and variables.
+- `PascalCase` for types/traits/enums.
+- `UPPER_SNAKE_CASE` for constants/statics.
+
+Keep protocol-specific changes scoped to the relevant module and prefer structured logging (`log` + `structured-logger`) over ad hoc prints.
+
+## Testing Guidelines
+Rust tests are colocated with code under `#[cfg(test)]`; async tests use `#[tokio::test]`. Name E2E tests by behavior (`test_connect_tunnel.py`, `test_auth_selection.py`, etc.).
+
+No explicit coverage threshold is enforced, but PRs should include:
+- unit tests for parsing/routing/auth logic changes
+- targeted E2E coverage for protocol, auth, reload, or hot-upgrade behavior changes
+
+## Commit & Pull Request Guidelines
+Recent history follows Conventional Commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:` (often with issue refs like `(#52)`).
+
+PRs should be focused and include:
+- clear summary and rationale
+- linked issue(s), if applicable
+- exact test commands run and results
+- config/security impact notes (especially auth headers, API keys, TLS/cert behavior)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,9 +118,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -122,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -146,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmake"
@@ -273,6 +279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +326,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +355,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -361,13 +395,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -393,10 +435,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.181"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "linux-raw-sys"
@@ -425,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
@@ -454,7 +502,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.11.6"
+version = "2.12.0"
 dependencies = [
  "bytes",
  "clap",
@@ -515,6 +563,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -644,15 +702,21 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -794,15 +858,15 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sval"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502b8906c4736190684646827fbab1e954357dfe541013bbd7994d033d53a1ca"
+checksum = "c1aaf178a50bbdd86043fce9bf0a5867007d9b382db89d1c96ccae4601ff1ff9"
 
 [[package]]
 name = "sval_buffer"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b854348b15b6c441bdd27ce9053569b016a0723eab2d015b1fd8e6abe4f708"
+checksum = "f89273e48f03807ebf51c4d81c52f28d35ffa18a593edf97e041b52de143df89"
 dependencies = [
  "sval",
  "sval_ref",
@@ -810,18 +874,18 @@ dependencies = [
 
 [[package]]
 name = "sval_dynamic"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd9e8b74410ddad37c6962587c5f9801a2caadba9e11f3f916ee3f31ae4a1f"
+checksum = "0430f4e18e7eba21a49d10d25a8dec3ce0e044af40b162347e99a8e3c3ced864"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_fmt"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe17b8deb33a9441280b4266c2d257e166bafbaea6e66b4b34ca139c91766d9"
+checksum = "835f51b9d7331b9d7fc48fc716c02306fa88c4a076b1573531910c91a525882d"
 dependencies = [
  "itoa",
  "ryu",
@@ -830,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "sval_json"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854addb048a5bafb1f496c98e0ab5b9b581c3843f03ca07c034ae110d3b7c623"
+checksum = "13cbfe3ef406ee2366e7e8ab3678426362085fa9eaedf28cb878a967159dced3"
 dependencies = [
  "itoa",
  "ryu",
@@ -841,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "sval_nested"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf068f482108ff44ae8013477cb047a1665d5f1a635ad7cf79582c1845dce9"
+checksum = "8b20358af4af787c34321a86618c3cae12eabdd0e9df22cd9dd2c6834214c518"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -852,18 +916,18 @@ dependencies = [
 
 [[package]]
 name = "sval_ref"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed02126365ffe5ab8faa0abd9be54fbe68d03d607cd623725b0a71541f8aaa6f"
+checksum = "fb5e500f8eb2efa84f75e7090f7fc43f621b9f8b6cde571c635b3855f97b332a"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_serde"
-version = "2.16.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a263383c6aa2076c4ef6011d3bae1b356edf6ea2613e3d8e8ebaa7b57dd707d5"
+checksum = "ca2032ae39b11dcc6c18d5fbc50a661ea191cac96484c59ccf49b002261ca2c1"
 dependencies = [
  "serde_core",
  "sval",
@@ -883,12 +947,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -992,9 +1056,15 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -1063,6 +1133,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1241,6 +1354,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1270,6 +1465,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.11.6"
+version = "2.12.0"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/e2e/test_openai_dynamic_api_key.py
+++ b/e2e/test_openai_dynamic_api_key.py
@@ -1,0 +1,380 @@
+"""
+E2E tests for OpenAI dynamic API key support.
+
+This test suite validates:
+1. api_key: $(command) uses dynamic Authorization: Bearer header upstream
+2. Standard (non-command) api_key behavior is unchanged
+3. Health checks also use dynamic API key when configured
+"""
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+
+def find_free_port() -> int:
+    """Find a free localhost TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return sock.getsockname()[1]
+
+
+def wait_for_port(host: str, port: int, timeout: float = 10.0) -> bool:
+    """Wait until a TCP port is accepting connections."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return True
+        except OSError:
+            time.sleep(0.1)
+    return False
+
+
+def find_openproxy_binary() -> str:
+    """Find openproxy binary from env or local build outputs."""
+    if "OPENPROXY_BINARY" in os.environ:
+        return os.environ["OPENPROXY_BINARY"]
+
+    candidates = [
+        Path(__file__).parent.parent / "target" / "release" / "openproxy",
+        Path(__file__).parent.parent / "target" / "debug" / "openproxy",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return str(candidate)
+
+    raise FileNotFoundError("Could not find openproxy binary")
+
+
+def start_openproxy(config_path: str, log_path: str):
+    """Start openproxy and redirect logs to file."""
+    binary = find_openproxy_binary()
+    log_handle = open(log_path, "w")
+    process = subprocess.Popen(
+        [binary, "start", "-c", config_path],
+        stdout=log_handle,
+        stderr=log_handle,
+    )
+    return process, log_handle
+
+
+def stop_process(process: subprocess.Popen):
+    """Terminate a subprocess gracefully."""
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+class MockOpenAIHandler(BaseHTTPRequestHandler):
+    """Mock upstream for OpenAI-style requests."""
+
+    received_headers = {}
+    authorization_values = []
+
+    def log_message(self, format, *args):
+        pass
+
+    @classmethod
+    def reset(cls):
+        cls.received_headers = {}
+        cls.authorization_values = []
+
+    def do_GET(self):
+        if self.path == "/health":
+            MockOpenAIHandler.received_headers = {
+                key.lower(): value for key, value in self.headers.items()
+            }
+            MockOpenAIHandler.authorization_values = (
+                self.headers.get_all("Authorization") or []
+            )
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"OK")
+            return
+
+        response = {"object": "list", "data": []}
+        response_body = json.dumps(response).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def do_POST(self):
+        MockOpenAIHandler.received_headers = {
+            key.lower(): value for key, value in self.headers.items()
+        }
+        MockOpenAIHandler.authorization_values = (
+            self.headers.get_all("Authorization") or []
+        )
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length > 0:
+            self.rfile.read(content_length)
+
+        response = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}}],
+        }
+        response_body = json.dumps(response).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+
+def start_mock_server(port: int):
+    """Start mock upstream server in background thread."""
+    server = HTTPServer(("127.0.0.1", port), MockOpenAIHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_dynamic_api_key_forwarding():
+    """Dynamic api_key command should be executed and forwarded as Authorization."""
+    import httpx
+    import yaml
+
+    print(f"\n{'=' * 60}")
+    print("Testing OpenAI Dynamic API Key Forwarding")
+    print("=" * 60)
+
+    upstream_port = find_free_port()
+    proxy_port = find_free_port()
+    MockOpenAIHandler.reset()
+    upstream_server = start_mock_server(upstream_port)
+
+    if not wait_for_port("127.0.0.1", upstream_port):
+        raise RuntimeError("Mock server failed to start")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.yml")
+        log_path = os.path.join(tmpdir, "openproxy.log")
+
+        config = {
+            "http_port": proxy_port,
+            "providers": [
+                {
+                    "type": "openai",
+                    "host": "openai-dynamic.local",
+                    "endpoint": "127.0.0.1",
+                    "port": upstream_port,
+                    "tls": False,
+                    "api_key": "$(echo sk-dynamic-openai-12345)",
+                }
+            ],
+        }
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(config, f)
+
+        proxy_process, proxy_log = start_openproxy(config_path, log_path)
+        try:
+            if not wait_for_port("127.0.0.1", proxy_port, timeout=30):
+                proxy_log.flush()
+                with open(log_path, "r", encoding="utf-8") as f:
+                    print(f.read())
+                raise RuntimeError("openproxy failed to start")
+
+            with httpx.Client(base_url=f"http://127.0.0.1:{proxy_port}", timeout=30, proxy=None) as client:
+                response = client.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Host": "openai-dynamic.local",
+                        "Content-Type": "application/json",
+                        "Authorization": "Bearer client-should-not-pass-through",
+                    },
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
+                )
+
+            assert response.status_code == 200, f"Unexpected status: {response.status_code}"
+            auth_values = MockOpenAIHandler.authorization_values
+            assert len(auth_values) == 1, f"Expected 1 Authorization header, got: {auth_values}"
+            assert auth_values[0] == "Bearer sk-dynamic-openai-12345", (
+                f"Unexpected Authorization header: {auth_values[0]}"
+            )
+            print("Authorization at upstream:", auth_values[0])
+            print("PASS: OpenAI dynamic API key forwarding test passed!")
+        finally:
+            stop_process(proxy_process)
+            proxy_log.close()
+            upstream_server.shutdown()
+            upstream_server.server_close()
+
+
+def test_standard_openai_api_key_still_works():
+    """Static api_key behavior should remain unchanged."""
+    import httpx
+    import yaml
+
+    print(f"\n{'=' * 60}")
+    print("Testing OpenAI Standard API Key Mode")
+    print("=" * 60)
+
+    upstream_port = find_free_port()
+    proxy_port = find_free_port()
+    MockOpenAIHandler.reset()
+    upstream_server = start_mock_server(upstream_port)
+
+    if not wait_for_port("127.0.0.1", upstream_port):
+        raise RuntimeError("Mock server failed to start")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.yml")
+        log_path = os.path.join(tmpdir, "openproxy.log")
+
+        config = {
+            "http_port": proxy_port,
+            "providers": [
+                {
+                    "type": "openai",
+                    "host": "openai-standard.local",
+                    "endpoint": "127.0.0.1",
+                    "port": upstream_port,
+                    "tls": False,
+                    "api_key": "sk-static-openai-67890",
+                }
+            ],
+        }
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(config, f)
+
+        proxy_process, proxy_log = start_openproxy(config_path, log_path)
+        try:
+            if not wait_for_port("127.0.0.1", proxy_port, timeout=30):
+                proxy_log.flush()
+                with open(log_path, "r", encoding="utf-8") as f:
+                    print(f.read())
+                raise RuntimeError("openproxy failed to start")
+
+            with httpx.Client(base_url=f"http://127.0.0.1:{proxy_port}", timeout=30, proxy=None) as client:
+                response = client.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "Host": "openai-standard.local",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": "gpt-4o-mini",
+                        "messages": [{"role": "user", "content": "hello"}],
+                    },
+                )
+
+            assert response.status_code == 200, f"Unexpected status: {response.status_code}"
+            auth_values = MockOpenAIHandler.authorization_values
+            assert len(auth_values) == 1, f"Expected 1 Authorization header, got: {auth_values}"
+            assert auth_values[0] == "Bearer sk-static-openai-67890", (
+                f"Unexpected Authorization header: {auth_values[0]}"
+            )
+            print("Authorization at upstream:", auth_values[0])
+            print("PASS: OpenAI standard mode regression test passed!")
+        finally:
+            stop_process(proxy_process)
+            proxy_log.close()
+            upstream_server.shutdown()
+            upstream_server.server_close()
+
+
+def test_dynamic_api_key_health_check():
+    """Health check should use dynamic Authorization header in command mode."""
+    import yaml
+
+    print(f"\n{'=' * 60}")
+    print("Testing OpenAI Dynamic API Key Health Check")
+    print("=" * 60)
+
+    upstream_port = find_free_port()
+    proxy_port = find_free_port()
+    MockOpenAIHandler.reset()
+    upstream_server = start_mock_server(upstream_port)
+
+    if not wait_for_port("127.0.0.1", upstream_port):
+        raise RuntimeError("Mock server failed to start")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = os.path.join(tmpdir, "config.yml")
+        log_path = os.path.join(tmpdir, "openproxy.log")
+
+        config = {
+            "http_port": proxy_port,
+            "health_check": {
+                "enabled": True,
+                "interval": 1,
+            },
+            "providers": [
+                {
+                    "type": "openai",
+                    "host": "openai-health.local",
+                    "endpoint": "127.0.0.1",
+                    "port": upstream_port,
+                    "tls": False,
+                    "api_key": "$(echo sk-dynamic-health-abc)",
+                    "health_check": {
+                        "path": "/health",
+                    },
+                }
+            ],
+        }
+        with open(config_path, "w", encoding="utf-8") as f:
+            yaml.dump(config, f)
+
+        proxy_process, proxy_log = start_openproxy(config_path, log_path)
+        try:
+            if not wait_for_port("127.0.0.1", proxy_port, timeout=30):
+                proxy_log.flush()
+                with open(log_path, "r", encoding="utf-8") as f:
+                    print(f.read())
+                raise RuntimeError("openproxy failed to start")
+
+            deadline = time.time() + 8.0
+            while time.time() < deadline and not MockOpenAIHandler.authorization_values:
+                time.sleep(0.2)
+
+            auth_values = MockOpenAIHandler.authorization_values
+            assert auth_values, "No health check request with Authorization header received"
+            assert len(auth_values) == 1, f"Expected 1 Authorization header, got: {auth_values}"
+            assert auth_values[0] == "Bearer sk-dynamic-health-abc", (
+                f"Unexpected health check Authorization: {auth_values[0]}"
+            )
+            print("Health check Authorization at upstream:", auth_values[0])
+            print("PASS: OpenAI dynamic API key health check test passed!")
+        finally:
+            stop_process(proxy_process)
+            proxy_log.close()
+            upstream_server.shutdown()
+            upstream_server.server_close()
+
+
+if __name__ == "__main__":
+    try:
+        test_dynamic_api_key_forwarding()
+        test_standard_openai_api_key_still_works()
+        test_dynamic_api_key_health_check()
+    except Exception as e:
+        print(f"ERROR: {e}")
+        sys.exit(1)
+
+    print("\n" + "=" * 60)
+    print("PASS: All OpenAI dynamic API key tests passed!")
+    print("=" * 60)

--- a/e2e/test_openai_dynamic_api_key.py
+++ b/e2e/test_openai_dynamic_api_key.py
@@ -477,12 +477,13 @@ def test_dynamic_api_key_websocket_upgrade():
                 raise RuntimeError("openproxy failed to start")
 
             with socket.create_connection(("127.0.0.1", proxy_port), timeout=10.0) as sock:
+                websocket_key = base64.b64encode(os.urandom(16)).decode("ascii")
                 ws_request = (
                     "GET /v1/realtime?model=gpt-4o-mini HTTP/1.1\r\n"
                     "Host: openai-ws-dynamic.local\r\n"
                     "Upgrade: websocket\r\n"
                     "Connection: Upgrade\r\n"
-                    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                    f"Sec-WebSocket-Key: {websocket_key}\r\n"
                     "Sec-WebSocket-Version: 13\r\n"
                     "Authorization: Bearer client-should-not-pass-through\r\n"
                     "\r\n"


### PR DESCRIPTION
## Summary
- add dynamic OpenAI upstream auth support via `api_key: "$(command)"` pattern (aligned with Anthropic dynamic auth behavior)
- apply dynamic upstream auth path to WebSocket flows (HTTP/1.1 and HTTP/2)
- add OpenAI dynamic api key e2e tests for forwarding, standard-mode regression, and health check behavior
- wire the new OpenAI dynamic api key e2e test into `.github/workflows/e2e.yml`
- add `AGENTS.md` repository contributor guidelines

## Validation
- `cargo test --lib`
- `python3 -m py_compile e2e/test_openai_dynamic_api_key.py`

## Notes
- e2e tests were intentionally not run locally; they will run in GitHub Actions after this PR is created.
