### PR TITLE
feat: add provider priority selection

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -189,6 +189,7 @@ jobs:
               endpoint: localhost
               port: 9002
               tls: false
+              priority: 10
               api_key: sk-api-key-1
               auth_keys:
                 - sk-auth-key-1
@@ -197,6 +198,7 @@ jobs:
               endpoint: localhost
               port: 9003
               tls: false
+              priority: 1
               api_key: sk-api-key-2
               auth_keys:
                 - sk-auth-key-2
@@ -205,6 +207,7 @@ jobs:
               endpoint: localhost
               port: 9004
               tls: false
+              priority: 100
               api_key: sk-api-key-fallback
               auth_keys:
                 - sk-auth-key-fallback
@@ -214,6 +217,7 @@ jobs:
               endpoint: localhost
               port: 9002
               tls: false
+              priority: 10
               api_key: sk-api-key-1
               auth_keys:
                 - sk-auth-key-1
@@ -222,6 +226,7 @@ jobs:
               endpoint: localhost
               port: 9003
               tls: false
+              priority: 1
               api_key: sk-api-key-2
               auth_keys:
                 - sk-auth-key-2
@@ -230,6 +235,7 @@ jobs:
               endpoint: localhost
               port: 9004
               tls: false
+              priority: 100
               api_key: sk-api-key-fallback
               auth_keys:
                 - sk-auth-key-fallback
@@ -751,6 +757,18 @@ jobs:
           cd e2e
           python test_auth_selection.py
           echo "Auth selection E2E tests passed!"
+
+      - name: Run Provider Priority E2E tests
+        env:
+          PROXY_HTTPS_PORT: 8443
+          PROXY_HTTP_PORT: 8080
+          SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
+          AUTH_KEY: ${{ env.AUTH_KEY }}
+        run: |
+          echo "Testing provider priority selection..."
+          cd e2e
+          python test_provider_priority.py
+          echo "Provider priority E2E tests passed!"
 
       - name: Run Health Check Auth E2E tests
         env:

--- a/e2e/test_provider_priority.py
+++ b/e2e/test_provider_priority.py
@@ -1,0 +1,64 @@
+"""
+E2E tests for provider priority selection.
+
+This test reuses the auth-selection providers configured by the workflow:
+- provider1: non-fallback, priority 10
+- provider2: non-fallback, priority 1
+- fallback: fallback, priority 100
+
+The request uses the global AUTH_KEY so all three providers can authenticate.
+Expected behavior:
+- provider1 wins because it is the highest-priority non-fallback provider
+- fallback must not override non-fallback selection even with a higher priority
+"""
+
+import os
+import httpx
+
+
+HTTPS_PORT = int(os.environ.get("PROXY_HTTPS_PORT", "8443"))
+HTTP_PORT = int(os.environ.get("PROXY_HTTP_PORT", "8080"))
+SSL_CERT_FILE = os.environ.get("SSL_CERT_FILE", "")
+AUTH_KEY = os.environ["AUTH_KEY"]
+
+
+def test_provider_priority_https():
+    """Highest-priority non-fallback provider should win over lower priority and fallback."""
+    print("\n=== Testing provider priority over HTTPS ===\n")
+
+    with httpx.Client(verify=SSL_CERT_FILE) as client:
+        resp = client.get(
+            f"https://localhost:{HTTPS_PORT}/v1/priority",
+            headers={
+                "Host": f"auth-test.local:{HTTPS_PORT}",
+                "Authorization": f"Bearer {AUTH_KEY}",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
+
+
+def test_provider_priority_http():
+    """Highest-priority non-fallback provider should also win on HTTP/1.1."""
+    print("\n=== Testing provider priority over HTTP ===\n")
+
+    with httpx.Client() as client:
+        resp = client.get(
+            f"http://localhost:{HTTP_PORT}/v1/priority",
+            headers={
+                "Host": f"auth-test.local:{HTTP_PORT}",
+                "Authorization": f"Bearer {AUTH_KEY}",
+            },
+        )
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+        data = resp.json()
+        assert data["server_id"] == "provider1", f"Expected provider1, got {data['server_id']}"
+        print(f"  -> Routed to: {data['server_id']} ✓")
+
+
+if __name__ == "__main__":
+    test_provider_priority_https()
+    test_provider_priority_http()
+    print("\n=== Provider priority E2E tests passed! ===\n")

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -67,7 +67,8 @@ impl<P: PoolTrait, H2P: H2PoolTrait + 'static> Executor<P, H2P> {
                             provider.set_healthy(false);
                             return;
                         };
-                        if let Err(e) = provider.health_check(&mut conn, http_max_header_size).await {
+                        if let Err(e) = provider.health_check(&mut conn, http_max_header_size).await
+                        {
                             if provider.is_healthy() {
                                 log::warn!(provider = provider.host(), api_key = provider_api_key(), error = e.to_string(); "health_check_error");
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,57 @@ fn program() -> Arc<RwLock<Program>> {
     Arc::clone(PROGRAM.get().unwrap())
 }
 
+fn keep_highest_priority<T, F>(candidates: Vec<T>, priority_of: F) -> Vec<T>
+where
+    F: Fn(&T) -> i32,
+{
+    let Some(highest_priority) = candidates
+        .iter()
+        .map(|candidate| priority_of(candidate))
+        .max()
+    else {
+        return candidates;
+    };
+
+    candidates
+        .into_iter()
+        .filter(|candidate| priority_of(candidate) == highest_priority)
+        .collect()
+}
+
+fn prefer_non_fallback<T, F>(candidates: Vec<T>, is_fallback_of: F) -> Vec<T>
+where
+    F: Fn(&T) -> bool,
+{
+    if candidates
+        .iter()
+        .any(|candidate| !is_fallback_of(candidate))
+    {
+        candidates
+            .into_iter()
+            .filter(|candidate| !is_fallback_of(candidate))
+            .collect()
+    } else {
+        candidates
+    }
+}
+
+fn select_weighted<T, F>(mut candidates: Vec<T>, weight_of: F) -> Option<T>
+where
+    F: Fn(&T) -> f64,
+{
+    match candidates.len() {
+        0 => None,
+        1 => candidates.pop(),
+        _ => {
+            let dist = WeightedIndex::new(candidates.iter().map(|candidate| weight_of(candidate)))
+                .expect("Failed to create WeightedIndex: invalid weights detected");
+            let selected_idx = rng().sample(&dist);
+            Some(candidates.swap_remove(selected_idx))
+        }
+    }
+}
+
 pub async fn load_config(
     path: impl AsRef<Path>,
     first_load: bool,
@@ -161,6 +212,7 @@ impl Program {
                         api_key_config
                             .weight
                             .unwrap_or(provider.weight.unwrap_or(1.0)),
+                        provider.priority,
                         Some(&api_key_config.key),
                         Arc::clone(&auth_keys),
                         provider.provider_auth_keys.clone(),
@@ -180,6 +232,7 @@ impl Program {
                         .as_ref()
                         .and_then(|cfg| cfg.weight)
                         .unwrap_or(provider.weight.unwrap_or(1.0)),
+                    provider.priority,
                     api_key_config.as_ref().map(|cfg| cfg.key.as_ref()),
                     Arc::clone(&auth_keys),
                     provider.provider_auth_keys.clone(),
@@ -256,28 +309,10 @@ impl Program {
             })
             .collect();
 
-        // Separate non-fallback and fallback providers
-        let (non_fallback, fallback): (Vec<_>, Vec<_>) = healthy_providers
-            .into_iter()
-            .partition(|p| !p.is_fallback());
+        let candidates = prefer_non_fallback(healthy_providers, |provider| provider.is_fallback());
+        let candidates = keep_highest_priority(candidates, |provider| provider.priority());
 
-        // Prefer non-fallback providers; only use fallback if no non-fallback providers exist
-        let candidates = if non_fallback.is_empty() {
-            fallback
-        } else {
-            non_fallback
-        };
-
-        match candidates.len() {
-            0 => None,
-            1 => Some(candidates[0]),
-            _ => {
-                let dist = WeightedIndex::new(candidates.iter().map(|p| p.weight()))
-                    .expect("Failed to create WeightedIndex: invalid weights detected");
-                let selected_idx = rng().sample(&dist);
-                Some(candidates[selected_idx])
-            }
-        }
+        select_weighted(candidates, |provider| provider.weight())
     }
 
     /// Get all providers matching host/path (ignoring health status and auth).
@@ -309,10 +344,12 @@ impl Program {
     /// This method tries to authenticate with each matching provider and returns
     /// the first one that authenticates successfully.
     ///
-    /// The authentication order is:
-    /// 1. Try all non-fallback providers first (with weighted random selection)
-    /// 2. If all non-fallback providers fail authentication, try fallback providers
-    /// 3. If all providers fail authentication, return None
+    /// The selection order is:
+    /// 1. Keep only healthy providers matching host/path
+    /// 2. Authenticate providers and keep the successful ones
+    /// 3. Prefer non-fallback providers
+    /// 4. Within that tier, keep only providers with the highest priority value
+    /// 5. If multiple providers remain, select by weight
     ///
     /// Returns a tuple of (provider, auth_type) where auth_type is the type returned
     /// by authenticate_with_type (e.g., "x-api-key" or "bearer").
@@ -368,29 +405,13 @@ impl Program {
             return Err(provider::AuthenticationError);
         }
 
-        // Separate authenticated providers into non-fallback and fallback
-        let (non_fallback, fallback): (Vec<_>, Vec<_>) = authenticated_providers
-            .into_iter()
-            .partition(|(p, _)| !p.is_fallback());
+        let candidates = prefer_non_fallback(authenticated_providers, |(provider, _)| {
+            provider.is_fallback()
+        });
+        let candidates = keep_highest_priority(candidates, |(provider, _)| provider.priority());
 
-        // Prefer non-fallback providers; only use fallback if no non-fallback providers authenticated
-        let candidates = if non_fallback.is_empty() {
-            fallback
-        } else {
-            non_fallback
-        };
-
-        // Select one provider based on weight
-        match candidates.len() {
-            0 => Err(provider::AuthenticationError),
-            1 => Ok(candidates.into_iter().next().unwrap()),
-            _ => {
-                let dist = WeightedIndex::new(candidates.iter().map(|(p, _)| p.weight()))
-                    .expect("Failed to create WeightedIndex: invalid weights detected");
-                let selected_idx = rng().sample(&dist);
-                Ok(candidates.into_iter().nth(selected_idx).unwrap())
-            }
-        }
+        select_weighted(candidates, |(provider, _)| provider.weight())
+            .ok_or(provider::AuthenticationError)
     }
 
     /// Check if any provider (ignoring health status) can authenticate with the given key.
@@ -493,6 +514,9 @@ struct ProviderConfig<'a> {
     port: Option<u16>,
     tls: Option<bool>,
     weight: Option<f64>,
+    /// Higher numbers are preferred first. Defaults to 0.
+    #[serde(default)]
+    priority: i32,
     #[serde(skip_serializing)]
     #[serde(borrow)]
     api_key: Option<APIKeys<'a>>,
@@ -827,6 +851,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-test"),
                 Arc::clone(&auth_keys),
                 None,
@@ -841,6 +866,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-fallback"),
                 Arc::clone(&auth_keys),
                 None,
@@ -890,6 +916,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-fallback1"),
                 Arc::clone(&auth_keys),
                 None,
@@ -904,6 +931,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-fallback2"),
                 Arc::clone(&auth_keys),
                 None,
@@ -947,6 +975,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-test"),
                 Arc::clone(&auth_keys),
                 None,
@@ -961,6 +990,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-fallback"),
                 Arc::clone(&auth_keys),
                 None,
@@ -998,6 +1028,182 @@ mod tests {
     }
 
     #[test]
+    fn test_select_provider_prefers_higher_priority() {
+        let auth_keys = Arc::new(vec![]);
+        let providers: Vec<Box<dyn provider::Provider>> = vec![
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "low-priority.openai.com",
+                None,
+                true,
+                1.0,
+                1,
+                Some("sk-low"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "high-priority.openai.com",
+                None,
+                true,
+                1.0,
+                10,
+                Some("sk-high"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        let program = Program {
+            tls_server_config: None,
+            https_port: None,
+            http_port: Some(8080),
+            https_bind_address: "0.0.0.0".to_string(),
+            http_bind_address: "0.0.0.0".to_string(),
+            http_max_header_size: 4096,
+            enable_health_check: false,
+            health_check_interval: 0,
+            graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            providers: Arc::new(providers),
+        };
+
+        for _ in 0..50 {
+            let selected = program
+                .select_provider("api.openai.com", "/v1/chat")
+                .unwrap();
+            assert_eq!(selected.endpoint(), "high-priority.openai.com");
+        }
+    }
+
+    #[test]
+    fn test_select_provider_falls_back_to_lower_priority_when_higher_unhealthy() {
+        let auth_keys = Arc::new(vec![]);
+        let providers: Vec<Box<dyn provider::Provider>> = vec![
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "high-priority.openai.com",
+                None,
+                true,
+                1.0,
+                10,
+                Some("sk-high"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "low-priority.openai.com",
+                None,
+                true,
+                1.0,
+                1,
+                Some("sk-low"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        providers[0].set_healthy(false);
+
+        let program = Program {
+            tls_server_config: None,
+            https_port: None,
+            http_port: Some(8080),
+            https_bind_address: "0.0.0.0".to_string(),
+            http_bind_address: "0.0.0.0".to_string(),
+            http_max_header_size: 4096,
+            enable_health_check: false,
+            health_check_interval: 0,
+            graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            providers: Arc::new(providers),
+        };
+
+        let selected = program
+            .select_provider("api.openai.com", "/v1/chat")
+            .unwrap();
+        assert_eq!(selected.endpoint(), "low-priority.openai.com");
+    }
+
+    #[test]
+    fn test_select_provider_preserves_fallback_precedence_across_priorities() {
+        let auth_keys = Arc::new(vec![]);
+        let providers: Vec<Box<dyn provider::Provider>> = vec![
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "high-priority-fallback.openai.com",
+                None,
+                true,
+                1.0,
+                10,
+                Some("sk-high-fallback"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                true,
+            )
+            .unwrap(),
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "low-priority-primary.openai.com",
+                None,
+                true,
+                1.0,
+                1,
+                Some("sk-low-primary"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        let program = Program {
+            tls_server_config: None,
+            https_port: None,
+            http_port: Some(8080),
+            https_bind_address: "0.0.0.0".to_string(),
+            http_bind_address: "0.0.0.0".to_string(),
+            http_max_header_size: 4096,
+            enable_health_check: false,
+            health_check_interval: 0,
+            graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            providers: Arc::new(providers),
+        };
+
+        let selected = program
+            .select_provider("api.openai.com", "/v1/chat")
+            .unwrap();
+        assert_eq!(selected.endpoint(), "low-priority-primary.openai.com");
+        assert!(!selected.is_fallback());
+    }
+
+    #[test]
     fn test_select_provider_with_auth_selects_authenticated_provider() {
         let auth_keys = Arc::new(vec!["valid-key".to_string()]);
         let providers: Vec<Box<dyn provider::Provider>> = vec![
@@ -1008,6 +1214,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-test1"),
                 Arc::clone(&auth_keys),
                 Some(vec!["key-for-provider1".to_string()]),
@@ -1022,6 +1229,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-test2"),
                 Arc::clone(&auth_keys),
                 Some(vec!["key-for-provider2".to_string()]),
@@ -1086,6 +1294,128 @@ mod tests {
     }
 
     #[test]
+    fn test_select_provider_with_auth_prefers_higher_priority() {
+        let auth_keys = Arc::new(vec!["valid-key".to_string()]);
+        let providers: Vec<Box<dyn provider::Provider>> = vec![
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "low-priority.openai.com",
+                None,
+                true,
+                1.0,
+                1,
+                Some("sk-low"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "high-priority.openai.com",
+                None,
+                true,
+                1.0,
+                10,
+                Some("sk-high"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        let program = Program {
+            tls_server_config: None,
+            https_port: None,
+            http_port: Some(8080),
+            https_bind_address: "0.0.0.0".to_string(),
+            http_bind_address: "0.0.0.0".to_string(),
+            http_max_header_size: 4096,
+            enable_health_check: false,
+            health_check_interval: 0,
+            graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            providers: Arc::new(providers),
+        };
+
+        let auth_header = b"Authorization: Bearer valid-key";
+        for _ in 0..50 {
+            let (provider, _) = program
+                .select_provider_with_auth("api.openai.com", "/v1/chat", |provider| {
+                    provider.authenticate_with_type(Some(auth_header))
+                })
+                .unwrap();
+            assert_eq!(provider.endpoint(), "high-priority.openai.com");
+        }
+    }
+
+    #[test]
+    fn test_select_provider_with_auth_uses_lower_priority_when_higher_cannot_authenticate() {
+        let auth_keys = Arc::new(vec![]);
+        let providers: Vec<Box<dyn provider::Provider>> = vec![
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "high-priority.openai.com",
+                None,
+                true,
+                1.0,
+                10,
+                Some("sk-high"),
+                Arc::clone(&auth_keys),
+                Some(vec!["key-for-high".to_string()]),
+                None,
+                false,
+            )
+            .unwrap(),
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "low-priority.openai.com",
+                None,
+                true,
+                1.0,
+                1,
+                Some("sk-low"),
+                Arc::clone(&auth_keys),
+                Some(vec!["key-for-low".to_string()]),
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        let program = Program {
+            tls_server_config: None,
+            https_port: None,
+            http_port: Some(8080),
+            https_bind_address: "0.0.0.0".to_string(),
+            http_bind_address: "0.0.0.0".to_string(),
+            http_max_header_size: 4096,
+            enable_health_check: false,
+            health_check_interval: 0,
+            graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            providers: Arc::new(providers),
+        };
+
+        let auth_header = b"Authorization: Bearer key-for-low";
+        let (provider, _) = program
+            .select_provider_with_auth("api.openai.com", "/v1/chat", |provider| {
+                provider.authenticate_with_type(Some(auth_header))
+            })
+            .unwrap();
+        assert_eq!(provider.endpoint(), "low-priority.openai.com");
+    }
+
+    #[test]
     fn test_select_provider_with_auth_tries_fallback_after_non_fallback() {
         let auth_keys = Arc::new(vec![]);
         let providers: Vec<Box<dyn provider::Provider>> = vec![
@@ -1096,6 +1426,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-primary"),
                 Arc::clone(&auth_keys),
                 Some(vec!["key-for-primary".to_string()]),
@@ -1110,6 +1441,7 @@ mod tests {
                 None,
                 true,
                 1.0,
+                0,
                 Some("sk-fallback"),
                 Arc::clone(&auth_keys),
                 Some(vec!["key-for-fallback".to_string()]),
@@ -1167,6 +1499,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             Arc::clone(&auth_keys),
             None,
@@ -1209,6 +1542,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             Arc::clone(&auth_keys),
             None, // No provider auth keys
@@ -1356,6 +1690,26 @@ providers:
         let config: Config = serde_yaml::from_str(yaml).unwrap();
         let program = Program::from_config(config).unwrap();
         assert_eq!(program.http_max_header_size, 1048576);
+    }
+
+    #[test]
+    fn test_provider_priority_parsing() {
+        let yaml = r#"
+http_port: 8080
+providers:
+  - type: openai
+    host: api.openai.com
+    endpoint: api.openai.com
+    api_key: sk-test
+    priority: 10
+  - type: openai
+    host: api.openai.com
+    endpoint: backup.openai.com
+    api_key: sk-backup
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.providers[0].priority, 10);
+        assert_eq!(config.providers[1].priority, 0);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1087,6 +1087,77 @@ mod tests {
     }
 
     #[test]
+    fn test_select_provider_same_priority_still_uses_weight() {
+        let auth_keys = Arc::new(vec![]);
+        let providers: Vec<Box<dyn provider::Provider>> = vec![
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "heavy-weight.openai.com",
+                None,
+                true,
+                9.0,
+                10,
+                Some("sk-heavy"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+            provider::new_provider(
+                "openai",
+                "api.openai.com",
+                "light-weight.openai.com",
+                None,
+                true,
+                1.0,
+                10,
+                Some("sk-light"),
+                Arc::clone(&auth_keys),
+                None,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        let program = Program {
+            tls_server_config: None,
+            https_port: None,
+            http_port: Some(8080),
+            https_bind_address: "0.0.0.0".to_string(),
+            http_bind_address: "0.0.0.0".to_string(),
+            http_max_header_size: 4096,
+            enable_health_check: false,
+            health_check_interval: 0,
+            graceful_shutdown_timeout: 5,
+            connect_tunnel_enabled: false,
+            shutdown_tx: tokio::sync::broadcast::channel(1).0,
+            providers: Arc::new(providers),
+        };
+
+        let mut heavy_count = 0;
+        let mut light_count = 0;
+        for _ in 0..2000 {
+            match program
+                .select_provider("api.openai.com", "/v1/chat")
+                .unwrap()
+                .endpoint()
+            {
+                "heavy-weight.openai.com" => heavy_count += 1,
+                "light-weight.openai.com" => light_count += 1,
+                endpoint => panic!("unexpected endpoint selected: {endpoint}"),
+            }
+        }
+
+        assert!(
+            heavy_count > light_count * 5,
+            "Expected heavy-weight provider to dominate selection, got heavy={heavy_count}, light={light_count}"
+        );
+    }
+
+    #[test]
     fn test_select_provider_falls_back_to_lower_priority_when_higher_unhealthy() {
         let auth_keys = Arc::new(vec![]);
         let providers: Vec<Box<dyn provider::Provider>> = vec![

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -29,6 +29,7 @@ pub fn new_provider(
     port: Option<u16>,
     tls: bool,
     weight: f64,
+    priority: i32,
     api_key: Option<&str>,
     auth_keys: Arc<Vec<String>>,
     provider_auth_keys: Option<Vec<String>>,
@@ -42,6 +43,7 @@ pub fn new_provider(
             port,
             tls,
             weight,
+            priority,
             api_key,
             auth_keys,
             provider_auth_keys,
@@ -54,6 +56,7 @@ pub fn new_provider(
             port,
             tls,
             weight,
+            priority,
             api_key,
             auth_keys,
             provider_auth_keys,
@@ -66,6 +69,7 @@ pub fn new_provider(
             port,
             tls,
             weight,
+            priority,
             api_key,
             auth_keys,
             provider_auth_keys,
@@ -78,6 +82,7 @@ pub fn new_provider(
             port,
             tls,
             weight,
+            priority,
             health_check_config,
             is_fallback,
         )?)),
@@ -118,6 +123,7 @@ pub trait Provider: Send + Sync {
     fn authenticate(&self, auth: Option<&[u8]>) -> Result<(), AuthenticationError>;
     fn authenticate_key(&self, key: &str) -> Result<(), AuthenticationError>;
     fn weight(&self) -> f64;
+    fn priority(&self) -> i32;
     fn is_fallback(&self) -> bool;
 
     /// Returns the path prefix that should be stripped from requests, if any.
@@ -251,6 +257,7 @@ pub struct OpenAIProvider {
     endpoint: Arc<str>,
     tls: bool,
     weight: f64,
+    priority: i32,
     host_header: String,
     auth_header: Option<String>,
     dynamic_api_key_command: Option<String>,
@@ -271,6 +278,7 @@ impl OpenAIProvider {
         port: Option<u16>,
         tls: bool,
         weight: f64,
+        priority: i32,
         api_key: Option<&str>,
         auth_keys: Arc<Vec<String>>,
         provider_auth_keys: Option<Vec<String>>,
@@ -306,6 +314,7 @@ impl OpenAIProvider {
             endpoint,
             tls,
             weight,
+            priority,
             host_header,
             auth_header,
             dynamic_api_key_command,
@@ -367,6 +376,10 @@ impl Provider for OpenAIProvider {
 
     fn weight(&self) -> f64 {
         self.weight
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
     }
 
     fn is_fallback(&self) -> bool {
@@ -481,6 +494,7 @@ pub struct GeminiProvider {
     endpoint: Arc<str>,
     tls: bool,
     weight: f64,
+    priority: i32,
     api_key: String,
     host_header: String,
     auth_header: String,
@@ -501,6 +515,7 @@ impl GeminiProvider {
         port: Option<u16>,
         tls: bool,
         weight: f64,
+        priority: i32,
         api_key: Option<&str>,
         auth_keys: Arc<Vec<String>>,
         provider_auth_keys: Option<Vec<String>>,
@@ -527,6 +542,7 @@ impl GeminiProvider {
             endpoint,
             tls,
             weight,
+            priority,
             api_key: api_key.to_string(),
             host_header,
             auth_header,
@@ -588,6 +604,10 @@ impl Provider for GeminiProvider {
 
     fn weight(&self) -> f64 {
         self.weight
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
     }
 
     fn is_fallback(&self) -> bool {
@@ -696,6 +716,7 @@ pub struct AnthropicProvider {
     endpoint: Arc<str>,
     tls: bool,
     weight: f64,
+    priority: i32,
     host_header: String,
     /// Static auth header (for x-api-key style authentication)
     auth_header: Option<String>,
@@ -750,6 +771,7 @@ impl AnthropicProvider {
         port: Option<u16>,
         tls: bool,
         weight: f64,
+        priority: i32,
         api_key: Option<&str>,
         auth_keys: Arc<Vec<String>>,
         provider_auth_keys: Option<Vec<String>>,
@@ -789,6 +811,7 @@ impl AnthropicProvider {
             endpoint,
             tls,
             weight,
+            priority,
             host_header,
             auth_header,
             oauth_command,
@@ -866,6 +889,10 @@ impl Provider for AnthropicProvider {
 
     fn weight(&self) -> f64 {
         self.weight
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
     }
 
     fn is_fallback(&self) -> bool {
@@ -1105,6 +1132,7 @@ pub struct ForwardProvider {
     endpoint: Arc<str>,
     tls: bool,
     weight: f64,
+    priority: i32,
     host_header: String,
     sock_address: String,
     server_name: rustls_pki_types::ServerName<'static>,
@@ -1121,6 +1149,7 @@ impl ForwardProvider {
         port: Option<u16>,
         tls: bool,
         weight: f64,
+        priority: i32,
         health_check_config: Option<HealthCheckConfig>,
         is_fallback: bool,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -1139,6 +1168,7 @@ impl ForwardProvider {
             endpoint,
             tls,
             weight,
+            priority,
             host_header,
             sock_address,
             server_name,
@@ -1196,6 +1226,10 @@ impl Provider for ForwardProvider {
 
     fn weight(&self) -> f64 {
         self.weight
+    }
+
+    fn priority(&self) -> i32 {
+        self.priority
     }
 
     fn is_fallback(&self) -> bool {
@@ -1351,6 +1385,7 @@ mod tests {
             None,
             true,
             1.0,
+            7,
             Some("sk-test-key"),
             auth_keys,
             None,
@@ -1364,6 +1399,7 @@ mod tests {
         assert_eq!(provider.endpoint(), "api.openai.com");
         assert_eq!(provider.api_key(), Some("sk-test-key"));
         assert_eq!(provider.weight(), 1.0);
+        assert_eq!(provider.priority(), 7);
         assert!(provider.tls());
         assert!(provider.is_healthy());
         assert_eq!(provider.sock_address(), "api.openai.com:443");
@@ -1385,6 +1421,7 @@ mod tests {
             Some(8080),
             false,
             2.0,
+            0,
             Some("sk-test"),
             auth_keys,
             None,
@@ -1407,6 +1444,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             auth_keys,
             None,
@@ -1443,6 +1481,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             auth_keys,
             None,
@@ -1467,6 +1506,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             auth_keys,
             provider_auth_keys,
@@ -1489,6 +1529,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None,
             auth_keys,
             None,
@@ -1518,6 +1559,7 @@ mod tests {
             None,
             true,
             1.5,
+            0,
             Some("gemini-api-key"),
             auth_keys,
             None,
@@ -1547,6 +1589,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None, // Missing API key
             auth_keys,
             None,
@@ -1566,6 +1609,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("gemini-api-key"),
             auth_keys,
             None,
@@ -1594,6 +1638,7 @@ mod tests {
             None,
             true,
             0.5,
+            0,
             Some("anthropic-api-key"),
             auth_keys,
             None,
@@ -1620,6 +1665,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None, // Missing API key
             auth_keys,
             None,
@@ -1639,6 +1685,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("anthropic-api-key"),
             auth_keys,
             None,
@@ -1667,6 +1714,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("anthropic-api-key"),
             auth_keys,
             None,
@@ -1697,6 +1745,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("anthropic-api-key"),
             auth_keys,
             None,
@@ -1727,6 +1776,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("anthropic-api-key"),
             auth_keys,
             None,
@@ -1750,6 +1800,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("upstream-api-key"),
             auth_keys,
             None,
@@ -1789,6 +1840,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(echo oauth-token)"),
             auth_keys,
             None,
@@ -1819,6 +1871,7 @@ mod tests {
             None,
             true,
             1.0,
+            9,
             Some("sk-test"),
             Arc::clone(&auth_keys),
             None,
@@ -1827,6 +1880,7 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(openai.kind(), Type::OpenAI));
+        assert_eq!(openai.priority(), 9);
 
         // Test Gemini
         let gemini = new_provider(
@@ -1836,6 +1890,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("gemini-key"),
             Arc::clone(&auth_keys),
             None,
@@ -1853,6 +1908,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("anthropic-key"),
             Arc::clone(&auth_keys),
             None,
@@ -1870,6 +1926,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("key"),
             Arc::clone(&auth_keys),
             None,
@@ -1890,6 +1947,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("key"),
             Arc::clone(&auth_keys),
             None,
@@ -1906,6 +1964,7 @@ mod tests {
             None,
             false,
             1.0,
+            0,
             Some("key"),
             Arc::clone(&auth_keys),
             None,
@@ -1922,6 +1981,7 @@ mod tests {
             Some(8443),
             true,
             1.0,
+            0,
             Some("key"),
             Arc::clone(&auth_keys),
             None,
@@ -1941,6 +2001,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None, // No API key
             auth_keys,
             None,
@@ -1962,6 +2023,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(echo dynamic-openai-key)"),
             auth_keys,
             None,
@@ -1998,6 +2060,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(exit 1)"),
             auth_keys,
             None,
@@ -2026,6 +2089,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("key"),
             auth_keys.clone(),
             None,
@@ -2049,6 +2113,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("key"),
             auth_keys,
             None,
@@ -2070,6 +2135,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("gemini-api-key"),
             auth_keys,
             None,
@@ -2106,6 +2172,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             auth_keys,
             None,
@@ -2130,6 +2197,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-test"),
             auth_keys,
             None,
@@ -2149,6 +2217,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("key"),
             Arc::new(vec!["valid-key".to_string()]),
             None,
@@ -2213,6 +2282,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(echo oauth-token-123)"),
             auth_keys,
             None,
@@ -2243,6 +2313,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-ant-api-key-123"),
             auth_keys,
             None,
@@ -2272,6 +2343,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(echo token)"),
             auth_keys,
             None,
@@ -2328,6 +2400,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("sk-ant-api-key-123"),
             auth_keys,
             None,
@@ -2359,6 +2432,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(nonexistent_command_that_will_fail_12345)"),
             auth_keys,
             None,
@@ -2386,6 +2460,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(printf '')"),
             auth_keys,
             None,
@@ -2414,6 +2489,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             Some("$(exit 1)"),
             auth_keys,
             None,
@@ -2440,6 +2516,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None,
             false,
         )
@@ -2468,6 +2545,7 @@ mod tests {
             Some(8080),
             false,
             2.0,
+            0,
             None,
             false,
         )
@@ -2487,6 +2565,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None,
             false,
         )
@@ -2511,6 +2590,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None,
             false,
         )
@@ -2539,6 +2619,7 @@ mod tests {
             None,
             true,
             1.0,
+            0,
             None,
             Arc::clone(&auth_keys),
             None,
@@ -2633,6 +2714,7 @@ mod tests {
             Some(8080),
             false,
             1.0,
+            0,
             Some(health_cfg),
             false,
         )


### PR DESCRIPTION
## Summary
- add provider-level `priority` support and prefer higher-priority providers during selection
- preserve existing fallback behavior by only applying priority within the active non-fallback/fallback tier
- add e2e coverage and GitHub Actions coverage for provider priority selection

## Tests
- `cargo test --lib --verbose`
- `python3 -m py_compile e2e/test_provider_priority.py`
- e2e not run locally by request; verify via PR checks
