### PR TITLE
fix(ci,h2): update trivy and harden upstream handling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -297,8 +297,7 @@ jobs:
 
       - name: Start openproxy
         run: |
-          ./target/release/openproxy start -c config.yml > /tmp/openproxy.log 2>&1 &
-          echo $! > openproxy.pid
+          ./target/release/openproxy start -c config.yml &
           sleep 3
           curl -k https://localhost:8443 || true
           curl http://localhost:8080 || true
@@ -952,7 +951,3 @@ jobs:
           cd e2e
           python test_connect_tunnel.py
           echo "CONNECT tunnel upstream unreachable test passed!"
-
-      - name: Print openproxy log on failure
-        if: failure()
-        run: tail -n 400 /tmp/openproxy.log || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -561,7 +561,7 @@ jobs:
             --http2 \
             -H "Host: gemini.localhost:8443" \
             -H "x-goog-api-key: ${PROXY_AUTH_KEY}" \
-            "https://localhost:8443/v1beta/models?key=placeholder&pageSize=1"
+            "https://localhost:8443/v1beta/models?pageSize=1"
 
           HTTP_CODE=$(head -1 /tmp/gemini_headers.txt | grep -oE '[0-9]{3}')
           echo "HTTP Status: $HTTP_CODE"
@@ -604,7 +604,7 @@ jobs:
           HTTP_CODE=$(curl -s -o /tmp/gemini_response_http.json -w "%{http_code}" \
             -H "Host: gemini.localhost:8080" \
             -H "x-goog-api-key: ${PROXY_AUTH_KEY}" \
-            "http://localhost:8080/v1beta/models?key=placeholder&pageSize=1")
+            "http://localhost:8080/v1beta/models?pageSize=1")
 
           echo "HTTP Status: $HTTP_CODE"
           cat /tmp/gemini_response_http.json | head -c 500

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -297,7 +297,8 @@ jobs:
 
       - name: Start openproxy
         run: |
-          ./target/release/openproxy start -c config.yml &
+          ./target/release/openproxy start -c config.yml > /tmp/openproxy.log 2>&1 &
+          echo $! > openproxy.pid
           sleep 3
           curl -k https://localhost:8443 || true
           curl http://localhost:8080 || true
@@ -951,3 +952,7 @@ jobs:
           cd e2e
           python test_connect_tunnel.py
           echo "CONNECT tunnel upstream unreachable test passed!"
+
+      - name: Print openproxy log on failure
+        if: failure()
+        run: tail -n 400 /tmp/openproxy.log || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -409,7 +409,7 @@ jobs:
           SSL_CERT_FILE: ${{ github.workspace }}/fullchain.pem
         run: |
           cd e2e
-          python test_openai_realtime.py --proxy-host localhost --proxy-port 8443 --ssl-cert $SSL_CERT_FILE --timeout 60
+          python test_openai_realtime.py --proxy-host localhost --proxy-port 8443 --ssl-cert $SSL_CERT_FILE --route-host api.openai.com --timeout 60
 
       - name: Start HTTP echo server for fallback test
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -601,9 +601,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -690,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openproxy"
-version = "2.13.1"
+version = "2.13.2"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openproxy"
 authors = ["Hei <xuboyu72@gmail.com>"]
-version = "2.13.1"
+version = "2.13.2"
 edition = "2021"
 description = "A LLM Proxy"
 

--- a/e2e/test_anthropic_api.py
+++ b/e2e/test_anthropic_api.py
@@ -60,7 +60,7 @@ def test_anthropic_messages_x_api_key_http1():
                 "anthropic-version": "2023-06-01",
             },
             json={
-                "model": "claude-3-haiku-20240307",
+                "model": "claude-haiku-4-5-20251001",
                 "max_tokens": 50,
                 "messages": [{"role": "user", "content": "Say 'Hello' in one word."}],
             },
@@ -110,7 +110,7 @@ def test_anthropic_chat_completions_bearer_http1():
                 "anthropic-version": "2023-06-01",
             },
             json={
-                "model": "claude-3-haiku-20240307",
+                "model": "claude-haiku-4-5-20251001",
                 "max_tokens": 50,
                 "messages": [{"role": "user", "content": "Say 'World' in one word."}],
             },
@@ -164,7 +164,7 @@ def test_anthropic_messages_x_api_key_http2():
                 "anthropic-version": "2023-06-01",
             },
             json={
-                "model": "claude-3-haiku-20240307",
+                "model": "claude-haiku-4-5-20251001",
                 "max_tokens": 50,
                 "messages": [{"role": "user", "content": "Say 'HTTP2' in one word."}],
             },
@@ -217,7 +217,7 @@ def test_anthropic_chat_completions_bearer_http2():
                 "anthropic-version": "2023-06-01",
             },
             json={
-                "model": "claude-3-haiku-20240307",
+                "model": "claude-haiku-4-5-20251001",
                 "max_tokens": 50,
                 "messages": [{"role": "user", "content": "Say 'Bearer' in one word."}],
             },
@@ -267,7 +267,7 @@ def test_openai_compatible_http1():
 
     print("Sending request via openai SDK (Chat Completions)...")
     response = client.chat.completions.create(
-        model="claude-3-haiku-20240307",
+        model="claude-haiku-4-5-20251001",
         max_tokens=50,
         messages=[{"role": "user", "content": "Say 'OpenAI' in one word."}],
     )
@@ -310,7 +310,7 @@ def test_openai_compatible_http2():
 
     print("Sending request via openai SDK (Chat Completions)...")
     response = client.chat.completions.create(
-        model="claude-3-haiku-20240307",
+        model="claude-haiku-4-5-20251001",
         max_tokens=50,
         messages=[{"role": "user", "content": "Say 'OpenAI' in one word."}],
     )

--- a/e2e/test_h2_upstream.py
+++ b/e2e/test_h2_upstream.py
@@ -77,10 +77,6 @@ def test_h2_upstream_basic():
         resp = _h2_chat_completions(client, api_key)
         print(f"Status: {resp.status_code}")
         print(f"HTTP Version: {resp.http_version}")
-        print(f"x-upstream-protocol: {resp.headers.get('x-upstream-protocol')}")
-        print(f"content-type: {resp.headers.get('content-type')}")
-        print(f"response headers: {dict(resp.headers)}")
-        print(f"body preview: {repr(resp.text[:1000])}")
 
         # Verify we're using HTTP/2 on the client side
         assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
@@ -246,7 +242,6 @@ def test_h2_upstream_error_handling():
         )
         print(f"Status: {resp.status_code}")
         print(f"HTTP Version: {resp.http_version}")
-        print(f"Body: {resp.text[:200] if len(resp.text) > 200 else resp.text}")
 
         assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
         assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"

--- a/e2e/test_h2_upstream.py
+++ b/e2e/test_h2_upstream.py
@@ -40,6 +40,10 @@ def test_h2_upstream_basic():
         )
         print(f"Status: {resp.status_code}")
         print(f"HTTP Version: {resp.http_version}")
+        print(f"x-upstream-protocol: {resp.headers.get('x-upstream-protocol')}")
+        print(f"content-type: {resp.headers.get('content-type')}")
+        print(f"response headers: {dict(resp.headers)}")
+        print(f"body preview: {repr(resp.text[:1000])}")
 
         # Verify we're using HTTP/2 on the client side
         assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"

--- a/e2e/test_h2_upstream.py
+++ b/e2e/test_h2_upstream.py
@@ -20,6 +20,48 @@ class EntitiesModel(BaseModel):
     animals: List[str]
 
 
+def _chat_completions_payload():
+    """Build a minimal chat/completions JSON payload."""
+    model = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+    return {
+        "model": model,
+        "messages": [
+            {"role": "user", "content": "ping"},
+        ],
+        "max_tokens": 1,
+    }
+
+
+def _h2_chat_completions(client, api_key, extra_headers=None):
+    """POST /chat/completions over the given httpx client with bearer auth."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return client.post(
+        "/chat/completions",
+        headers=headers,
+        json=_chat_completions_payload(),
+    )
+
+
+async def _h2_chat_completions_async(client, api_key, extra_headers=None):
+    """Async POST /chat/completions over the given httpx AsyncClient."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+    return await client.post(
+        "/chat/completions",
+        headers=headers,
+        json=_chat_completions_payload(),
+    )
+
+
 def test_h2_upstream_basic():
     """Test basic HTTP/2 upstream connectivity."""
     print(f"\n{'='*50}")
@@ -31,13 +73,8 @@ def test_h2_upstream_basic():
     ssl_cert = os.environ.get("SSL_CERT_FILE")
 
     # Use HTTP/2 client
-    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert) as client:
-        resp = client.get(
-            "/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-            },
-        )
+    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=60) as client:
+        resp = _h2_chat_completions(client, api_key)
         print(f"Status: {resp.status_code}")
         print(f"HTTP Version: {resp.http_version}")
         print(f"x-upstream-protocol: {resp.headers.get('x-upstream-protocol')}")
@@ -106,14 +143,7 @@ def test_h2_upstream_multiplexing():
     # Make multiple concurrent requests over the same HTTP/2 connection
     async def make_async_requests():
         async with httpx.AsyncClient(base_url=base_url, http2=True, verify=ssl_cert, timeout=60) as client:
-            tasks = []
-            for i in range(5):
-                task = client.get(
-                    "/models",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                )
-                tasks.append(task)
-
+            tasks = [_h2_chat_completions_async(client, api_key) for _ in range(5)]
             responses = await asyncio.gather(*tasks)
 
             for i, resp in enumerate(responses):
@@ -180,12 +210,9 @@ def test_h2_upstream_connection_reuse():
 
     # Make sequential requests and verify they succeed
     # HTTP/2 should reuse the same connection
-    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=30) as client:
+    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=60) as client:
         for i in range(5):
-            resp = client.get(
-                "/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
+            resp = _h2_chat_completions(client, api_key)
             print(f"  Request {i+1}: Status {resp.status_code}")
             assert resp.status_code == 200, f"Request {i+1} failed with status {resp.status_code}"
             assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
@@ -194,27 +221,39 @@ def test_h2_upstream_connection_reuse():
 
 
 def test_h2_upstream_error_handling():
-    """Test HTTP/2 upstream error handling (404 from upstream)."""
+    """Test HTTP/2 proxy-side no-provider error handling.
+
+    Avoids depending on upstream /models or /nonexistent-endpoint reliability.
+    Targets a non-existent provider host so the proxy itself returns the
+    no-provider response over HTTP/2.
+    """
     print(f"\n{'='*50}")
-    print("Testing HTTP/2 upstream error handling")
+    print("Testing HTTP/2 proxy no-provider error handling")
     print('='*50)
 
     base_url = os.environ["OPENAI_BASE_URL"]
     api_key = os.environ["OPENAI_API_KEY"]
     ssl_cert = os.environ.get("SSL_CERT_FILE")
 
-    # Test with invalid endpoint - should get 404 from upstream
-    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert) as client:
+    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=30) as client:
         resp = client.get(
-            "/nonexistent-endpoint",
-            headers={"Authorization": f"Bearer {api_key}"},
+            "/models",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Host": "no-such-provider.local",
+            },
+            extensions={"authority": "no-such-provider.local"},
         )
-        print(f"Invalid endpoint: Status {resp.status_code}")
+        print(f"Status: {resp.status_code}")
         print(f"HTTP Version: {resp.http_version}")
+        print(f"Body: {resp.text[:200] if len(resp.text) > 200 else resp.text}")
+
         assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
         assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+        assert "no provider found" in resp.text.lower(), \
+            f"Expected 'no provider found' in body, got: {resp.text!r}"
 
-    print("\u2713 HTTP/2 upstream error handling test passed!")
+    print("\u2713 HTTP/2 proxy no-provider error handling test passed!")
 
 
 def test_h2_invalid_auth_key():
@@ -263,10 +302,7 @@ def test_h2_upstream_concurrent_streams():
 
     def make_request(i):
         with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=60) as client:
-            resp = client.get(
-                "/models",
-                headers={"Authorization": f"Bearer {api_key}"},
-            )
+            resp = _h2_chat_completions(client, api_key)
             return i, resp.status_code, resp.http_version
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
@@ -294,11 +330,11 @@ def test_h2_upstream_headers_preservation():
     ssl_cert = os.environ.get("SSL_CERT_FILE")
 
     # Add custom headers and verify the request succeeds
-    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert) as client:
-        resp = client.get(
-            "/models",
-            headers={
-                "Authorization": f"Bearer {api_key}",
+    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=60) as client:
+        resp = _h2_chat_completions(
+            client,
+            api_key,
+            extra_headers={
                 "X-Custom-Header": "test-value",
                 "Accept": "application/json",
                 "User-Agent": "openproxy-e2e-test/1.0",

--- a/e2e/test_https.py
+++ b/e2e/test_https.py
@@ -143,22 +143,24 @@ def test_no_provider_found_https_http2():
     ssl_cert = os.environ.get("SSL_CERT_FILE")
 
     # HTTP/2 mode
-    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert) as client:
+    with httpx.Client(base_url=base_url, http2=True, verify=ssl_cert, timeout=10) as client:
         resp = client.get(
             "/models",
             headers={
                 "Authorization": f"Bearer {api_key}",
-                # In HTTP/2, :authority pseudo-header is used instead of Host
-                # httpx will handle this
+                "Host": "no-such-provider.local",
             },
-            extensions={"authority": "no-such-provider.local"},  # Try to override authority
+            extensions={"authority": "no-such-provider.local"},
         )
 
-    print("Status:", resp.status_code)
-    print("Body:", resp.text[:200] if len(resp.text) > 200 else resp.text)
+    print(f"Status: {resp.status_code}")
+    print(f"HTTP Version: {resp.http_version}")
+    print(f"Body: {resp.text[:200] if len(resp.text) > 200 else resp.text}")
 
-    # HTTP/2 may handle this differently, accept 404 or valid response if authority override doesn't work
-    print(f"  -> Status: {resp.status_code}")
+    assert resp.http_version == "HTTP/2", f"Expected HTTP/2, got {resp.http_version}"
+    assert resp.status_code == 404, f"Expected 404, got {resp.status_code}"
+    assert "no provider found" in resp.text.lower(), \
+        f"Expected 'no provider found' in body, got: {resp.text!r}"
 
     print("\u2713 HTTPS HTTP/2 no-provider-found test passed!")
 

--- a/e2e/test_openai_realtime.py
+++ b/e2e/test_openai_realtime.py
@@ -48,6 +48,7 @@ class OpenAIRealtimeTest:
         ssl_cert: Optional[str] = None,
         model: str = "gpt-4o-realtime-preview-2024-12-17",
         timeout: int = 30,
+        route_host: Optional[str] = None,
     ):
         self.api_key = api_key
         self.proxy_host = proxy_host
@@ -55,6 +56,7 @@ class OpenAIRealtimeTest:
         self.ssl_cert = ssl_cert
         self.model = model
         self.timeout = timeout
+        self.route_host = route_host or ("api.openai.com" if proxy_host else None)
 
         self.ws: Optional[websocket.WebSocketApp] = None
         self.connected = False
@@ -80,9 +82,10 @@ class OpenAIRealtimeTest:
             f"Authorization: Bearer {self.api_key}",
             "OpenAI-Beta: realtime=v1",
         ]
-        if self.proxy_host:
-            # Add Host header for proxy to route correctly
-            headers.append("Host: api.openai.com")
+        # Note: Do not append a Host header here. websocket-client manages the
+        # Host header itself; passing one as a custom header can result in
+        # duplicate Host headers and a 400 from strict upstreams. When
+        # proxying, the actual Host is supplied via run_forever(host=...).
         return headers
 
     def on_open(self, ws):
@@ -177,6 +180,8 @@ class OpenAIRealtimeTest:
         print('='*60)
         print(f"URL: {url}")
         print(f"Proxy: {self.proxy_host}:{self.proxy_port}" if self.proxy_host else "Proxy: None (direct)")
+        if self.proxy_host:
+            print(f"Route Host: {self.route_host}")
         print(f"Model: {self.model}")
         print('='*60)
 
@@ -201,8 +206,26 @@ class OpenAIRealtimeTest:
         )
 
         # Run in a separate thread
+        run_kwargs: Dict[str, Any] = {}
+        if sslopt:
+            run_kwargs["sslopt"] = sslopt
+        if self.proxy_host and self.route_host:
+            # Tell websocket-client to use the upstream host as the Host header
+            # instead of the proxy address. This avoids duplicate/incorrect
+            # Host headers reaching upstream.
+            run_kwargs["host"] = self.route_host
+            # Avoid forwarding an Origin based on localhost when proxying, if
+            # the installed websocket-client supports the kwarg.
+            try:
+                import inspect
+                sig = inspect.signature(self.ws.run_forever)
+                if "suppress_origin" in sig.parameters:
+                    run_kwargs["suppress_origin"] = True
+            except (TypeError, ValueError):
+                pass
+
         ws_thread = threading.Thread(
-            target=lambda: self.ws.run_forever(sslopt=sslopt if sslopt else None)
+            target=lambda: self.ws.run_forever(**run_kwargs)
         )
         ws_thread.daemon = True
         ws_thread.start()
@@ -273,8 +296,14 @@ def main():
     )
     parser.add_argument(
         "--model",
-        default="gpt-4o-realtime-preview-2024-12-17",
-        help="Model to use (default: gpt-4o-realtime-preview-2024-12-17)"
+        default=os.environ.get("OPENAI_REALTIME_MODEL", "gpt-4o-realtime-preview-2024-12-17"),
+        help="Model to use (default: env OPENAI_REALTIME_MODEL or gpt-4o-realtime-preview-2024-12-17)"
+    )
+    parser.add_argument(
+        "--route-host",
+        default=os.environ.get("OPENAI_REALTIME_ROUTE_HOST"),
+        help="Upstream Host header value to send when proxying "
+             "(default: OPENAI_REALTIME_ROUTE_HOST env var or api.openai.com)"
     )
     parser.add_argument(
         "--timeout",
@@ -309,6 +338,7 @@ def main():
         ssl_cert=args.ssl_cert,
         model=args.model,
         timeout=args.timeout,
+        route_host=args.route_host,
     )
 
     success = test.run()

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -1010,13 +1010,14 @@ impl UpstreamInfo {
 
         // Copy response headers
         for (key, value) in parts.headers.iter() {
-            if !is_http2_invalid_headers(key.as_str()) {
+            if !is_http2_invalid_headers(key.as_str()) && !is_upstream_protocol_header(key.as_str())
+            {
                 builder = builder.header(key, value);
             }
         }
 
         // Add header to indicate upstream protocol
-        builder = builder.header("x-upstream-protocol", "h2");
+        builder = builder.header(UPSTREAM_PROTOCOL_HEADER, "h2");
 
         let response_has_body = !upstream_body.is_end_stream();
 
@@ -1197,7 +1198,7 @@ impl UpstreamInfo {
             {
                 is_transfer_encoding_chunked = true;
             }
-            if !is_http2_invalid_headers(header.name) {
+            if !is_http2_invalid_headers(header.name) && !is_upstream_protocol_header(header.name) {
                 builder = builder.header(header.name, header.value);
             }
         }
@@ -1218,7 +1219,7 @@ impl UpstreamInfo {
         }
 
         // Add header to indicate upstream protocol
-        builder = builder.header("x-upstream-protocol", "http/1.1");
+        builder = builder.header(UPSTREAM_PROTOCOL_HEADER, "http/1.1");
 
         let mut send = match respond.send_response(builder.body(()).unwrap(), false) {
             Ok(send) => send,
@@ -2170,6 +2171,13 @@ fn base64_encode(data: &[u8]) -> String {
     }
 
     result
+}
+
+const UPSTREAM_PROTOCOL_HEADER: &str = "x-upstream-protocol";
+
+#[inline]
+fn is_upstream_protocol_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case(UPSTREAM_PROTOCOL_HEADER)
 }
 
 #[inline]
@@ -3222,6 +3230,113 @@ mod tests {
             .unwrap();
         assert!(req_str.starts_with("GET /test HTTP/1.1\r\n"));
         assert!(req_str.contains(&format!("Host: localhost:{}\r\n", upstream_port)));
+    }
+
+    #[tokio::test]
+    async fn test_h2_fallback_to_h1_single_x_upstream_protocol_not_comma_joined() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::time::{timeout, Duration};
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+
+            let mut buf = vec![0u8; 8192];
+            let mut n = 0usize;
+            loop {
+                let read = socket.read(&mut buf[n..]).await.unwrap();
+                if read == 0 {
+                    break;
+                }
+                n += read;
+                if find_header_end(&buf[..n]).is_some() {
+                    break;
+                }
+                if n >= buf.len() {
+                    break;
+                }
+            }
+
+            let body = "OK";
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nX-Upstream-Protocol: h2, h2\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            socket.write_all(resp.as_bytes()).await.unwrap();
+            let _ = socket.shutdown().await;
+        });
+
+        let pool = Arc::new(crate::executor::Pool::<Conn>::new());
+        let h2pool = Arc::new(crate::h2client::H2Pool::new());
+
+        let (client_io, server_io) = tokio::io::duplex(64 * 1024);
+        let (mut client, client_conn) = h2::client::handshake(client_io).await.unwrap();
+        tokio::spawn(async move {
+            let _ = client_conn.await;
+        });
+
+        let pool_for_server = pool.clone();
+        let h2pool_for_server = h2pool.clone();
+        tokio::spawn(async move {
+            let mut server = h2::server::handshake(server_io).await.unwrap();
+            while let Some(next) = server.accept().await {
+                let (request, respond) = next.unwrap();
+                let mut worker = Worker::new(pool_for_server.clone(), h2pool_for_server.clone());
+                let info = UpstreamInfo {
+                    endpoint: "localhost".to_string(),
+                    sock_address: format!("127.0.0.1:{}", upstream_port),
+                    use_tls: false,
+                    max_header_size: 4096,
+                    host_header_value: format!("localhost:{}", upstream_port),
+                    auth_header: None,
+                    auth_header_keys: vec![],
+                    path_prefix: None,
+                    api_key: None,
+                    auth_query_key: None,
+                    extra_header_keys: vec![],
+                    extra_headers_transformed: vec![],
+                };
+
+                tokio::spawn(async move {
+                    info.proxy_h1(&mut worker, request, respond).await;
+                });
+            }
+        });
+
+        let request = httplib::Request::builder()
+            .method(httplib::Method::GET)
+            .uri("https://route.example.com/test")
+            .header("content-length", "0")
+            .body(())
+            .unwrap();
+        let (response_fut, _send_stream) = client.send_request(request, true).unwrap();
+
+        let response = timeout(Duration::from_secs(2), response_fut)
+            .await
+            .expect("timeout waiting for h2 response")
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let values: Vec<&str> = response
+            .headers()
+            .get_all(UPSTREAM_PROTOCOL_HEADER)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert_eq!(values, vec!["http/1.1"]);
+    }
+
+    // H2->H2 response header copy uses the same `is_upstream_protocol_header` predicate as H2->H1 fallback.
+    #[test]
+    fn test_is_upstream_protocol_header_predicate() {
+        assert!(is_upstream_protocol_header("x-upstream-protocol"));
+        assert!(is_upstream_protocol_header("X-Upstream-Protocol"));
+        assert!(is_upstream_protocol_header("X-UPSTREAM-PROTOCOL"));
+        assert!(!is_upstream_protocol_header("x-upstream-protocol-extra"));
+        assert!(!is_upstream_protocol_header("x-other"));
     }
 
     #[tokio::test]

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -839,11 +839,23 @@ struct UpstreamInfo {
 }
 
 #[inline]
+fn is_safe_idempotent_method(method: &httplib::Method) -> bool {
+    matches!(
+        *method,
+        httplib::Method::GET
+            | httplib::Method::HEAD
+            | httplib::Method::OPTIONS
+            | httplib::Method::TRACE
+    )
+}
+
+#[inline]
 fn stale_h2_retry_eligible_for_response_error(
     stale_retry_budget: u8,
     has_request_body: bool,
+    method: &httplib::Method,
 ) -> bool {
-    stale_retry_budget > 0 && !has_request_body
+    stale_retry_budget > 0 && !has_request_body && is_safe_idempotent_method(method)
 }
 
 impl UpstreamInfo {
@@ -1029,7 +1041,11 @@ impl UpstreamInfo {
                     break 'attempt resp;
                 }
                 Err(e) => {
-                    if !stale_h2_retry_eligible_for_response_error(stale_retry_budget, has_body) {
+                    if !stale_h2_retry_eligible_for_response_error(
+                        stale_retry_budget,
+                        has_body,
+                        &parts.method,
+                    ) {
                         worker.h2pool.remove(&self.endpoint).await;
                         invalid!(respond, 502, format!("upstream response: {}", e));
                         return;
@@ -2530,10 +2546,42 @@ mod tests {
 
     #[test]
     fn test_stale_h2_retry_eligible_for_response_error() {
-        assert!(stale_h2_retry_eligible_for_response_error(1, false));
-        assert!(!stale_h2_retry_eligible_for_response_error(1, true));
-        assert!(!stale_h2_retry_eligible_for_response_error(0, false));
-        assert!(!stale_h2_retry_eligible_for_response_error(0, true));
+        let get = httplib::Method::GET;
+        let head = httplib::Method::HEAD;
+        let options = httplib::Method::OPTIONS;
+        let trace = httplib::Method::TRACE;
+        let post = httplib::Method::POST;
+        let patch = httplib::Method::PATCH;
+        let delete = httplib::Method::DELETE;
+        let put = httplib::Method::PUT;
+
+        // Safe + idempotent methods without body and with retry budget: retryable.
+        assert!(stale_h2_retry_eligible_for_response_error(1, false, &get));
+        assert!(stale_h2_retry_eligible_for_response_error(1, false, &head));
+        assert!(stale_h2_retry_eligible_for_response_error(
+            1, false, &options
+        ));
+        assert!(stale_h2_retry_eligible_for_response_error(1, false, &trace));
+
+        // Non-safe methods are never retryable, even bodyless with budget.
+        assert!(!stale_h2_retry_eligible_for_response_error(1, false, &post));
+        assert!(!stale_h2_retry_eligible_for_response_error(
+            1, false, &patch
+        ));
+        assert!(!stale_h2_retry_eligible_for_response_error(
+            1, false, &delete
+        ));
+        assert!(!stale_h2_retry_eligible_for_response_error(1, false, &put));
+
+        // Any request with body is not retryable.
+        assert!(!stale_h2_retry_eligible_for_response_error(1, true, &get));
+        assert!(!stale_h2_retry_eligible_for_response_error(1, true, &head));
+        assert!(!stale_h2_retry_eligible_for_response_error(1, true, &post));
+
+        // Zero retry budget is not retryable.
+        assert!(!stale_h2_retry_eligible_for_response_error(0, false, &get));
+        assert!(!stale_h2_retry_eligible_for_response_error(0, false, &post));
+        assert!(!stale_h2_retry_eligible_for_response_error(0, true, &get));
     }
 
     #[test]

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -776,8 +776,7 @@ where
                     // Drop the read lock before async operations
                     drop(p);
 
-                    // Try to get or create HTTP/2 connection to upstream
-                    let h2result = match worker
+                    let (h2result, reused_from_pool) = match worker
                         .get_or_create_h2(&info.endpoint, &info.sock_address, info.use_tls)
                         .await
                     {
@@ -790,7 +789,8 @@ where
 
                     match h2result {
                         H2ConnectResult::H2(h2conn) => {
-                            info.proxy_h2(h2conn, request, respond).await;
+                            info.proxy_h2(&mut worker, reused_from_pool, h2conn, request, respond)
+                                .await;
                         }
                         H2ConnectResult::FallbackToH1 => {
                             info.proxy_h1(&mut worker, request, respond).await;
@@ -838,14 +838,89 @@ struct UpstreamInfo {
     extra_headers_transformed: Vec<(String, String)>,
 }
 
+#[inline]
+fn stale_h2_retry_eligible_for_response_error(
+    stale_retry_budget: u8,
+    has_request_body: bool,
+) -> bool {
+    stale_retry_budget > 0 && !has_request_body
+}
+
 impl UpstreamInfo {
-    /// Proxy request to upstream using HTTP/2.
-    async fn proxy_h2(
+    fn build_h2_upstream_request_payload(
         &self,
-        h2conn: crate::h2client::H2Connection,
-        request: httplib::Request<h2::RecvStream>,
+        parts: &httplib::request::Parts,
+    ) -> Result<httplib::Request<()>, String> {
+        let raw_path = parts
+            .uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("/");
+        let path = build_upstream_path(
+            raw_path,
+            self.path_prefix.as_deref(),
+            self.api_key.as_deref(),
+            self.auth_query_key,
+        );
+
+        let upstream_uri = httplib::Uri::builder()
+            .scheme(if self.use_tls { "https" } else { "http" })
+            .authority(self.host_header_value.as_str())
+            .path_and_query(path.as_str())
+            .build()
+            .map_err(|e| format!("invalid upstream uri: {}", e))?;
+
+        let mut upstream_request = httplib::Request::builder()
+            .method(parts.method.clone())
+            .uri(upstream_uri)
+            .version(httplib::Version::HTTP_2);
+
+        for (key, value) in parts.headers.iter() {
+            let key_str = key.as_str();
+            if key_str.starts_with(':') || is_http2_invalid_headers(key_str) {
+                continue;
+            }
+            if key_str.eq_ignore_ascii_case("host") {
+                upstream_request = upstream_request.header("host", self.host_header_value.as_str());
+                continue;
+            }
+            if should_filter_forwarded_header(
+                key_str,
+                &self.auth_header_keys,
+                &self.extra_header_keys,
+            ) {
+                continue;
+            }
+            upstream_request = upstream_request.header(key, value);
+        }
+
+        if let Some(ref auth) = self.auth_header {
+            if let Some((header_name, header_value)) = parse_auth_header(auth) {
+                upstream_request = upstream_request.header(header_name, header_value);
+            }
+        }
+
+        for (name, value) in &self.extra_headers_transformed {
+            upstream_request = upstream_request.header(name.as_str(), value.as_str());
+        }
+
+        upstream_request
+            .body(())
+            .map_err(|e| format!("build request: {}", e))
+    }
+
+    async fn proxy_h2<P, H2P>(
+        &self,
+        worker: &mut Worker<P, H2P>,
+        reused_from_pool: bool,
+        mut h2conn: crate::h2client::H2Connection,
+        mut request: httplib::Request<h2::RecvStream>,
         mut respond: h2::server::SendResponse<bytes::Bytes>,
-    ) {
+    ) where
+        P: PoolTrait + Send + Sync + 'static,
+        H2P: H2PoolTrait + Send + Sync + 'static,
+        <P as PoolTrait>::Item: ConnTrait + Unpin + Send + Sync,
+    {
         macro_rules! invalid {
             ($respond:expr, $status:expr, $msg:expr) => {{
                 let msg: Cow<str> = $msg.into();
@@ -868,148 +943,125 @@ impl UpstreamInfo {
             }};
         }
 
-        let mut send_request = h2conn.send_request();
+        let mut stale_retry_budget = u8::from(reused_from_pool);
 
-        // Build the upstream request path
-        let raw_path = request
-            .uri()
-            .path_and_query()
-            .map(|pq| pq.as_str())
-            .unwrap_or("/");
-        let path = build_upstream_path(
-            raw_path,
-            self.path_prefix.as_deref(),
-            self.api_key.as_deref(),
-            self.auth_query_key,
-        );
+        let upstream_response = 'attempt: loop {
+            let (parts, recv) = request.into_parts();
+            let has_body = !recv.is_end_stream();
+            let mut recv_opt = Some(recv);
 
-        // Build upstream URI
-        let upstream_uri = httplib::Uri::builder()
-            .scheme(if self.use_tls { "https" } else { "http" })
-            .authority(self.host_header_value.as_str())
-            .path_and_query(path.as_str())
-            .build();
-
-        let upstream_uri = match upstream_uri {
-            Ok(uri) => uri,
-            Err(e) => {
-                invalid!(respond, 502, format!("invalid upstream uri: {}", e));
-                return;
-            }
-        };
-
-        // Build the request to send to upstream
-        let mut upstream_request = httplib::Request::builder()
-            .method(request.method().clone())
-            .uri(upstream_uri)
-            .version(httplib::Version::HTTP_2);
-
-        // Copy headers, filtering out HTTP/2 pseudo-headers and connection-specific headers
-        for (key, value) in request.headers() {
-            let key_str = key.as_str();
-            // Skip pseudo-headers (they start with :) and connection-specific headers
-            if key_str.starts_with(':') || is_http2_invalid_headers(key_str) {
-                continue;
-            }
-            // Replace Host header with upstream host
-            if key_str.eq_ignore_ascii_case("host") {
-                upstream_request = upstream_request.header("host", self.host_header_value.as_str());
-                continue;
-            }
-            if should_filter_forwarded_header(
-                key_str,
-                &self.auth_header_keys,
-                &self.extra_header_keys,
-            ) {
-                continue;
-            }
-            upstream_request = upstream_request.header(key, value);
-        }
-
-        // Add provider's auth header if present
-        if let Some(ref auth) = self.auth_header {
-            if let Some((header_name, header_value)) = parse_auth_header(auth) {
-                upstream_request = upstream_request.header(header_name, header_value);
-            }
-        }
-
-        // Add transformed extra headers
-        for (name, value) in &self.extra_headers_transformed {
-            upstream_request = upstream_request.header(name.as_str(), value.as_str());
-        }
-
-        let upstream_request = match upstream_request.body(()) {
-            Ok(req) => req,
-            Err(e) => {
-                invalid!(respond, 502, format!("build request: {}", e));
-                return;
-            }
-        };
-
-        // Get the request body
-        let recv_body = request.into_body();
-
-        // Check if request has a body
-        let has_body = !recv_body.is_end_stream();
-
-        // Send the request
-        let (upstream_response, mut upstream_send_body) =
-            match send_request.send_request(upstream_request, !has_body) {
-                Ok(res) => res,
-                Err(e) => {
-                    invalid!(respond, 502, format!("upstream send: {}", e));
+            let upstream_request = match self.build_h2_upstream_request_payload(&parts) {
+                Ok(req) => req,
+                Err(msg) => {
+                    invalid!(respond, 502, msg);
                     return;
                 }
             };
 
-        // Stream the request body to upstream if present
-        if has_body {
-            let mut body_reader = H2StreamReader::new(recv_body);
-            let mut buf = vec![0u8; 16384];
-            loop {
-                match body_reader.read(&mut buf).await {
-                    Ok(0) => {
-                        if let Err(e) = body_reader.discard_trailers().await {
-                            log::error!(alpn = "h2", error = e.to_string(); "discard_client_request_trailers_error");
+            let mut send_request = h2conn.send_request();
+            let (upstream_response, mut upstream_send_body) =
+                match send_request.send_request(upstream_request, !has_body) {
+                    Ok(res) => res,
+                    Err(e) => {
+                        if stale_retry_budget == 0 {
+                            worker.h2pool.remove(&self.endpoint).await;
+                            invalid!(respond, 502, format!("upstream send: {}", e));
                             return;
                         }
-                        if let Err(e) = upstream_send_body.send_data(bytes::Bytes::new(), true) {
-                            log::error!(alpn = "h2", error = e.to_string(); "upstream_send_body_end_error");
+                        stale_retry_budget = 0;
+                        request = httplib::Request::from_parts(parts, recv_opt.take().unwrap());
+                        match worker
+                            .refresh_h2_upstream(&self.endpoint, &self.sock_address, self.use_tls)
+                            .await
+                        {
+                            Ok(H2ConnectResult::H2(c)) => {
+                                h2conn = c;
+                                continue 'attempt;
+                            }
+                            Ok(H2ConnectResult::FallbackToH1) => {
+                                return self.proxy_h1(worker, request, respond).await;
+                            }
+                            Err(e2) => {
+                                invalid!(respond, 502, format!("upstream: {}", e2));
+                                return;
+                            }
                         }
-                        break;
                     }
-                    Ok(n) => {
-                        let data = bytes::Bytes::copy_from_slice(&buf[..n]);
-                        if let Err(e) = upstream_send_body.send_data(data, false) {
-                            log::error!(alpn = "h2", error = e.to_string(); "upstream_send_body_error");
+                };
+
+            if has_body {
+                let recv = recv_opt.take().unwrap();
+                let mut body_reader = H2StreamReader::new(recv);
+                let mut buf = vec![0u8; 16384];
+                loop {
+                    match body_reader.read(&mut buf).await {
+                        Ok(0) => {
+                            if let Err(e) = body_reader.discard_trailers().await {
+                                log::error!(alpn = "h2", error = e.to_string(); "discard_client_request_trailers_error");
+                                return;
+                            }
+                            if let Err(e) = upstream_send_body.send_data(bytes::Bytes::new(), true)
+                            {
+                                log::error!(alpn = "h2", error = e.to_string(); "upstream_send_body_end_error");
+                            }
+                            break;
+                        }
+                        Ok(n) => {
+                            let data = bytes::Bytes::copy_from_slice(&buf[..n]);
+                            if let Err(e) = upstream_send_body.send_data(data, false) {
+                                log::error!(alpn = "h2", error = e.to_string(); "upstream_send_body_error");
+                                break;
+                            }
+                        }
+                        Err(e) => {
+                            log::error!(alpn = "h2", error = e.to_string(); "read_client_body_error");
                             break;
                         }
                     }
-                    Err(e) => {
-                        log::error!(alpn = "h2", error = e.to_string(); "read_client_body_error");
-                        break;
+                }
+            }
+
+            match upstream_response.await {
+                Ok(resp) => {
+                    if let Some(r) = recv_opt.take() {
+                        drop(r);
+                    }
+                    break 'attempt resp;
+                }
+                Err(e) => {
+                    if !stale_h2_retry_eligible_for_response_error(stale_retry_budget, has_body) {
+                        worker.h2pool.remove(&self.endpoint).await;
+                        invalid!(respond, 502, format!("upstream response: {}", e));
+                        return;
+                    }
+                    stale_retry_budget = 0;
+                    request = httplib::Request::from_parts(parts, recv_opt.take().unwrap());
+                    match worker
+                        .refresh_h2_upstream(&self.endpoint, &self.sock_address, self.use_tls)
+                        .await
+                    {
+                        Ok(H2ConnectResult::H2(c)) => {
+                            h2conn = c;
+                            continue 'attempt;
+                        }
+                        Ok(H2ConnectResult::FallbackToH1) => {
+                            return self.proxy_h1(worker, request, respond).await;
+                        }
+                        Err(e2) => {
+                            invalid!(respond, 502, format!("upstream: {}", e2));
+                            return;
+                        }
                     }
                 }
             }
-        }
-
-        // Wait for the response
-        let upstream_response = match upstream_response.await {
-            Ok(resp) => resp,
-            Err(e) => {
-                invalid!(respond, 502, format!("upstream response: {}", e));
-                return;
-            }
         };
 
-        // Build response to send back to client
-        let (parts, mut upstream_body) = upstream_response.into_parts();
+        let (res_parts, mut upstream_body) = upstream_response.into_parts();
         let mut builder = httplib::Response::builder()
             .version(httplib::Version::HTTP_2)
-            .status(parts.status);
+            .status(res_parts.status);
 
-        // Copy response headers
-        for (key, value) in parts.headers.iter() {
+        for (key, value) in res_parts.headers.iter() {
             if !is_http2_invalid_headers(key.as_str()) && !is_upstream_protocol_header(key.as_str())
             {
                 builder = builder.header(key, value);
@@ -1346,26 +1398,35 @@ where
         self.pool.add(endpoint, conn).await;
     }
 
-    /// Gets an existing HTTP/2 connection from the pool or creates a new one.
-    /// Returns `H2ConnectResult::FallbackToH1` if upstream doesn't support HTTP/2.
-    async fn get_or_create_h2(
+    async fn refresh_h2_upstream(
         &self,
         endpoint: &str,
         sock_address: &str,
         use_tls: bool,
     ) -> Result<H2ConnectResult, Error> {
-        // Try to get an existing connection
-        if let Some(conn) = self.h2pool.get(endpoint).await {
-            return Ok(H2ConnectResult::H2(conn));
-        }
-
-        // Try to create a new connection
+        self.h2pool.remove(endpoint).await;
         let result = h2client::connect_h2(endpoint, sock_address, use_tls).await?;
         if let H2ConnectResult::H2(ref conn) = result {
-            // Store it in the pool for future use (H2 connections are multiplexed)
             self.h2pool.insert(endpoint, conn.clone()).await;
         }
         Ok(result)
+    }
+
+    async fn get_or_create_h2(
+        &self,
+        endpoint: &str,
+        sock_address: &str,
+        use_tls: bool,
+    ) -> Result<(H2ConnectResult, bool), Error> {
+        if let Some(conn) = self.h2pool.get(endpoint).await {
+            return Ok((H2ConnectResult::H2(conn), true));
+        }
+
+        let result = h2client::connect_h2(endpoint, sock_address, use_tls).await?;
+        if let H2ConnectResult::H2(ref conn) = result {
+            self.h2pool.insert(endpoint, conn.clone()).await;
+        }
+        Ok((result, false))
     }
 
     /// Gets an existing HTTP/1.1 connection from the pool or creates a new one.
@@ -2466,6 +2527,14 @@ fn replace_query_param_value(path: &str, query_key: &str, new_value: &str) -> St
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_stale_h2_retry_eligible_for_response_error() {
+        assert!(stale_h2_retry_eligible_for_response_error(1, false));
+        assert!(!stale_h2_retry_eligible_for_response_error(1, true));
+        assert!(!stale_h2_retry_eligible_for_response_error(0, false));
+        assert!(!stale_h2_retry_eligible_for_response_error(0, true));
+    }
 
     #[test]
     fn test_base64_encode_empty() {
@@ -3787,14 +3856,20 @@ mod tests {
             let _ = client_conn.await;
         });
 
+        let pool = Arc::new(crate::executor::Pool::<Conn>::new());
+        let h2pool = Arc::new(crate::h2client::H2Pool::new());
         tokio::spawn(async move {
             let mut proxy = h2::server::handshake(proxy_io).await.unwrap();
             while let Some(next) = proxy.accept().await {
                 let (request, respond) = next.unwrap();
                 let info = info.clone();
                 let h2conn = h2conn.clone();
+                let pool = pool.clone();
+                let h2pool = h2pool.clone();
                 tokio::spawn(async move {
-                    info.proxy_h2(h2conn, request, respond).await;
+                    let mut worker = Worker::new(pool, h2pool);
+                    info.proxy_h2(&mut worker, false, h2conn, request, respond)
+                        .await;
                 });
             }
         });
@@ -3923,14 +3998,20 @@ mod tests {
             let _ = client_conn.await;
         });
 
+        let pool = Arc::new(crate::executor::Pool::<Conn>::new());
+        let h2pool = Arc::new(crate::h2client::H2Pool::new());
         tokio::spawn(async move {
             let mut proxy = h2::server::handshake(proxy_io).await.unwrap();
             while let Some(next) = proxy.accept().await {
                 let (request, respond) = next.unwrap();
                 let info = info.clone();
                 let h2conn = h2conn.clone();
+                let pool = pool.clone();
+                let h2pool = h2pool.clone();
                 tokio::spawn(async move {
-                    info.proxy_h2(h2conn, request, respond).await;
+                    let mut worker = Worker::new(pool, h2pool);
+                    info.proxy_h2(&mut worker, false, h2conn, request, respond)
+                        .await;
                 });
             }
         });


### PR DESCRIPTION
## Summary
- Pin `aquasecurity/trivy-action` to **v0.35.0** in the Security Scan workflow.
- Bump the crate version to **2.13.2** for the intended release.
- Refresh `Cargo.lock` to clear current `cargo audit` advisories.
- Fix HTTP/2 upstream proxy behavior by preventing duplicate `x-upstream-protocol` headers and retrying stale pooled H2 connections safely.
- Stabilize secret-backed E2E coverage for H2 upstream, Realtime WebSocket routing, HTTPS no-provider handling, Gemini auth, and Anthropic model selection.

## Test plan
- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --verbose`
- `cargo audit`
- GitHub Actions `E2E Tests` #25014282198 passed before the version-bump-only commit
- GitHub Actions `Security Scan` #25014282191 passed before the version-bump-only commit

## Issues
Closes #64, closes #63, closes #62, closes #61, closes #59, closes #58, closes #57
